### PR TITLE
Yet more pytests

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -49,5 +49,5 @@ jobs:
         
     - name: Test with pytest
       run: |
-        pytest .
+        DOWNLOAD_GROUND_TRUTHS=1 pytest -s .
 

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -39,5 +39,5 @@ jobs:
     - name: Test with pytest
       run: |
         mamba install pytest
-        pytest
+        DOWNLOAD_GROUND_TRUTHS=1 pytest -s .
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -617,7 +617,7 @@ def test_cnmfe():
     # test to check caiman get_pnr_image()
     pnr_image = df.iloc[-1].caiman.get_pnr_image()
     pnr_image_actual = numpy.load(ground_truths_dir.joinpath('cnmfe_partial', 'cnmfe_partial_pnr_img.npy'))
-    numpy.testing.assert_array_equal(pnr_image, pnr_image_actual)
+    numpy.testing.assert_allclose(pnr_image, pnr_image_actual, rtol=1e-4, atol=1e-10)
 
     # extension tests - full
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -223,7 +223,7 @@ def test_mcorr():
 
     # test to check mcorr get_output()
     mcorr_output = df.iloc[-1].mcorr.get_output()
-    mcorr_output_actual = numpy.load('ground_truths/mcorr/mcorr_output.npy')
+    mcorr_output_actual = numpy.load(ground_truths_dir.joinpath('mcorr', 'mcorr_output.npy'))
     numpy.testing.assert_array_equal(mcorr_output, mcorr_output_actual)
 
     # test to check caiman get_input_movie_path()
@@ -231,23 +231,23 @@ def test_mcorr():
 
     # test to check caiman get_correlation_img()
     mcorr_corr_img = df.iloc[-1].caiman.get_correlation_image()
-    mcorr_corr_img_actual = numpy.load('ground_truths/mcorr/mcorr_correlation_img.npy')
+    mcorr_corr_img_actual = numpy.load(ground_truths_dir.joinpath('mcorr', 'mcorr_correlation_img.npy'))
     numpy.testing.assert_array_equal(mcorr_corr_img, mcorr_corr_img_actual)
 
     # test to check caiman get_projection("mean")
     mcorr_mean = df.iloc[-1].caiman.get_projection("mean")
-    mcorr_mean_actual = numpy.load('ground_truths/mcorr/mcorr_mean.npy')
+    mcorr_mean_actual = numpy.load(ground_truths_dir.joinpath('mcorr', 'mcorr_mean.npy'))
     numpy.testing.assert_array_equal(mcorr_mean, mcorr_mean_actual)
 
     # test to check caiman get_projection("std")
     mcorr_std = df.iloc[-1].caiman.get_projection("std")
-    mcorr_std_actual = numpy.load('ground_truths/mcorr/mcorr_std.npy')
+    mcorr_std_actual = numpy.load(ground_truths_dir.joinpath('mcorr', 'mcorr_std.npy'))
     numpy.testing.assert_array_equal(mcorr_std, mcorr_std_actual)
 
     # test to check caiman get_projection("max")
     mcorr_max = df.iloc[-1].caiman.get_projection("max")
-    mcorr_max_actual = numpy.load('ground_truths/mcorr/mcorr_max.npy')
-    numpy.testing.assert_array_equal(mcorr_max,mcorr_max_actual)
+    mcorr_max_actual = numpy.load(ground_truths_dir.joinpath('mcorr', 'mcorr_max.npy'))
+    numpy.testing.assert_array_equal(mcorr_max, mcorr_max_actual)
 
 
 def test_cnmf():
@@ -378,13 +378,13 @@ def test_cnmf():
     print("testing cnmf.get_cnmf_memmap()")
     # test to check cnmf get_cnmf_memmap()
     cnmf_mmap_output = df.iloc[-1].cnmf.get_cnmf_memmap()
-    cnmf_mmap_output_actual = numpy.load('ground_truths/cnmf/cnmf_output_mmap.npy')
+    cnmf_mmap_output_actual = numpy.load(ground_truths_dir.joinpath('cnmf', 'cnmf_output_mmap.npy'))
     numpy.testing.assert_array_equal(cnmf_mmap_output, cnmf_mmap_output_actual)
 
     print("testing cnmf.get_input_memmap()")
     # test to check cnmf get_input_memmap()
     cnmf_input_mmap = df.iloc[-1].cnmf.get_input_memmap()
-    cnmf_input_mmap_actual = numpy.load('ground_truths/cnmf/cnmf_input_mmap.npy')
+    cnmf_input_mmap_actual = numpy.load(ground_truths_dir.joinpath('cnmf', 'cnmf_input_mmap.npy'))
     numpy.testing.assert_array_equal(cnmf_input_mmap, cnmf_input_mmap_actual)
     # cnmf input memmap from mcorr output should also equal mcorr output
     mcorr_output = df.iloc[-2].mcorr.get_output()
@@ -401,22 +401,22 @@ def test_cnmf():
 
     # test to check cnmf get_spatial_masks()
     cnmf_spatial_masks = df.iloc[-1].cnmf.get_spatial_masks()
-    cnmf_spatial_masks_actual = numpy.load('ground_truths/cnmf/spatial_masks.npy')
+    cnmf_spatial_masks_actual = numpy.load(ground_truths_dir.joinpath('cnmf', 'spatial_masks.npy'))
     numpy.testing.assert_array_equal(cnmf_spatial_masks, cnmf_spatial_masks_actual)
 
     # test to check get_spatial_contours()
     # cnmf_spatial_contours = df.iloc[-1].cnmf.get_spatial_contours()
-    # cnmf_spatial_contours_actual = numpy.load('ground_truths/cnmf/spatial_contours.npy', allow_pickle=True)
+    # cnmf_spatial_contours_actual = numpy.load(ground_truths_dir.joinpath('cnmf', 'spatial_contours.npy'), allow_pickle=True)
     # numpy.testing.assert_allclose(cnmf_spatial_contours, cnmf_spatial_contours_actual, rtol=1e-2, atol=1e-10)
 
     # test to check get_temporal_components()
     cnmf_temporal_components = df.iloc[-1].cnmf.get_temporal_components()
-    cnmf_temporal_components_actual = numpy.load('ground_truths/cnmf/temporal_components.npy')
+    cnmf_temporal_components_actual = numpy.load(ground_truths_dir.joinpath('cnmf', 'temporal_components.npy'))
     numpy.testing.assert_allclose(cnmf_temporal_components, cnmf_temporal_components_actual, rtol=1e-2, atol=1e-10)
 
     # test to check get_reconstructed_movie()
     cnmf_reconstructed_movie = df.iloc[-1].cnmf.get_reconstructed_movie()
-    cnmf_reconstructed_movie_actual = numpy.load('ground_truths/cnmf/reconstructed_movie.npy')
+    cnmf_reconstructed_movie_actual = numpy.load(ground_truths_dir.joinpath('cnmf', 'reconstructed_movie.npy'))
     numpy.testing.assert_allclose(cnmf_reconstructed_movie, cnmf_reconstructed_movie_actual, rtol=1e-2, atol=1e-10)
 
     # test to check caiman get_input_movie_path()
@@ -424,22 +424,22 @@ def test_cnmf():
 
     # test to check caiman get_correlation_img()
     cnmf_corr_img = df.iloc[-1].caiman.get_correlation_image()
-    cnmf_corr_img_actual = numpy.load('ground_truths/cnmf/cnmf_correlation_img.npy')
+    cnmf_corr_img_actual = numpy.load(ground_truths_dir.joinpath('cnmf', 'cnmf_correlation_img.npy'))
     numpy.testing.assert_array_equal(cnmf_corr_img, cnmf_corr_img_actual)
 
     # test to check caiman get_projection("mean")
     cnmf_mean = df.iloc[-1].caiman.get_projection("mean")
-    cnmf_mean_actual = numpy.load('ground_truths/cnmf/cnmf_mean.npy')
+    cnmf_mean_actual = numpy.load(ground_truths_dir.joinpath('cnmf', 'cnmf_mean.npy'))
     numpy.testing.assert_array_equal(cnmf_mean, cnmf_mean_actual)
 
     # test to check caiman get_projection("std")
     cnmf_std = df.iloc[-1].caiman.get_projection("std")
-    cnmf_std_actual = numpy.load('ground_truths/cnmf/cnmf_std.npy')
+    cnmf_std_actual = numpy.load(ground_truths_dir.joinpath('cnmf', 'cnmf_std.npy'))
     numpy.testing.assert_array_equal(cnmf_std, cnmf_std_actual)
 
     # test to check caiman get_projection("max")
     cnmf_max = df.iloc[-1].caiman.get_projection("std")
-    cnmf_max_actual = numpy.load('ground_truths/cnmf/cnmf_std.npy')
+    cnmf_max_actual = numpy.load(ground_truths_dir.joinpath('cnmf', 'cnmf_std.npy'))
     numpy.testing.assert_array_equal(cnmf_max, cnmf_max_actual)
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -35,7 +35,7 @@ os.makedirs(vid_dir, exist_ok=True)
 os.makedirs(ground_truths_dir, exist_ok=True)
 
 
-if len(list(ground_truths_dir.iterdir())) == 0:
+def _download_ground_truths():
     print(f'Downloading ground truths')
     url = f'https://zenodo.org/record/6590661/files/ground_truths.zip'
 
@@ -52,6 +52,14 @@ if len(list(ground_truths_dir.iterdir())) == 0:
     progress_bar.close()
 
     ZipFile(ground_truths_file).extractall(ground_truths_dir.parent)
+
+
+if len(list(ground_truths_dir.iterdir())) == "bah":
+    _download_ground_truths()
+
+elif "DOWNLOAD_GROUND_TRUTHS" in os.environ.keys():
+    if os.environ["DOWNLOAD_GROUND_TRUTHS"] == "1":
+        _download_ground_truths()
 
 
 def get_tmp_filename():

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -38,7 +38,7 @@ os.makedirs(ground_truths_dir, exist_ok=True)
 
 def _download_ground_truths():
     print(f'Downloading ground truths')
-    url = f'https://zenodo.org/record/6591921/files/ground_truths.zip'
+    url = f'https://zenodo.org/record/6592084/files/ground_truths.zip'
 
     # basically from https://stackoverflow.com/questions/37573483/progress-bar-while-download-file-over-http-with-requests/37573701
     response = requests.get(url, stream=True)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -55,7 +55,7 @@ def _download_ground_truths():
     ZipFile(ground_truths_file).extractall(ground_truths_dir.parent)
 
 
-if len(list(ground_truths_dir.iterdir())) == "bah":
+if len(list(ground_truths_dir.iterdir())) == 0:
     _download_ground_truths()
 
 elif "DOWNLOAD_GROUND_TRUTHS" in os.environ.keys():

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -38,7 +38,7 @@ os.makedirs(ground_truths_dir, exist_ok=True)
 
 def _download_ground_truths():
     print(f'Downloading ground truths')
-    url = f'https://zenodo.org/record/6590661/files/ground_truths.zip'
+    url = f'https://zenodo.org/record/6591921/files/ground_truths.zip'
 
     # basically from https://stackoverflow.com/questions/37573483/progress-bar-while-download-file-over-http-with-requests/37573701
     response = requests.get(url, stream=True)
@@ -407,9 +407,16 @@ def test_cnmf():
     numpy.testing.assert_array_equal(cnmf_spatial_masks, cnmf_spatial_masks_actual)
 
     # test to check get_spatial_contours()
-    # cnmf_spatial_contours = df.iloc[-1].cnmf.get_spatial_contours()
-    # cnmf_spatial_contours_actual = numpy.load(ground_truths_dir.joinpath('cnmf', 'spatial_contours.npy'), allow_pickle=True)
-    # numpy.testing.assert_allclose(cnmf_spatial_contours, cnmf_spatial_contours_actual, rtol=1e-2, atol=1e-10)
+    cnmf_spatial_contours_contours = df.iloc[-1].cnmf.get_spatial_contours()[0]
+    cnmf_spatial_contours_coms = df.iloc[-1].cnmf.get_spatial_contours()[1]
+    cnmf_spatial_contours_contours_actual = \
+        numpy.load(ground_truths_dir.joinpath('cnmf', 'spatial_contours_contours.npy'), allow_pickle=True)
+    cnmf_spatial_contours_coms_actual = \
+        numpy.load(ground_truths_dir.joinpath('cnmf', 'spatial_contours_coms.npy'), allow_pickle=True)
+    for contour, actual_contour in zip(cnmf_spatial_contours_contours, cnmf_spatial_contours_contours_actual):
+        numpy.testing.assert_allclose(contour, actual_contour, rtol=1e-2, atol=1e-10)
+    for com, actual_com in zip(cnmf_spatial_contours_coms, cnmf_spatial_contours_coms_actual):
+        numpy.testing.assert_allclose(com, actual_com, rtol=1e-2, atol=1e-10)
 
     # test to check get_temporal_components()
     cnmf_temporal_components = df.iloc[-1].cnmf.get_temporal_components()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -24,6 +24,7 @@ from uuid import UUID
 from pathlib import Path
 import shutil
 from zipfile import ZipFile
+from hashlib import sha1
 
 tmp_dir = Path(os.path.dirname(os.path.abspath(__file__)), "tmp")
 vid_dir = Path(os.path.dirname(os.path.abspath(__file__)), "videos")
@@ -395,9 +396,10 @@ def test_cnmf():
             vid_dir.joinpath(df.iloc[-1]["outputs"]["cnmf-hdf5-path"]))
 
     # test to check cnmf get_output()
-    # assert isinstance(df.iloc[-1].cnmf.get_output(), cnmf.CNMF)
-    # assert (df.iloc[1].cnmf.get_output() ==
-    #         load_dict_from_hdf5(df.iloc[-1].cnmf.get_output_path()))
+    assert isinstance(df.iloc[-1].cnmf.get_output(), cnmf.CNMF)
+    # this doesn't work because some keys in the hdf5 file are
+    # not always identical, like the path to the mmap file
+    # assert sha1(open(df.iloc[1].cnmf.get_output_path(), "rb").read()).hexdigest() == sha1(open(ground_truths_dir.joinpath('cnmf', 'cnmf_output.hdf5'), "rb").read()).hexdigest()
 
     # test to check cnmf get_spatial_masks()
     cnmf_spatial_masks = df.iloc[-1].cnmf.get_spatial_masks()


### PR DESCRIPTION
uploading ground truths to zenodo 

tests for extensions mcorr, cnmf, still need to implement cnmfe tests

all ground truths present 