### PR TITLE
save hdf5 file for good components

### DIFF
--- a/mesmerize_core/caiman_extensions/cnmf.py
+++ b/mesmerize_core/caiman_extensions/cnmf.py
@@ -252,3 +252,12 @@ class CNMFExtensions:
                 cnmf_obj.estimates.f[:, ixs_frames[0] : ixs_frames[1]]
             )
         return dn.reshape(cnmf_obj.dims + (-1,), order="F").transpose([2, 0, 1])
+
+
+    def save_hdf5_file(self, good_components):
+        cnmf_obj = self.get_output()
+        cnmf_obj.estimates.idx_components = good_components
+        output_path = self.get_output_path()
+        CNMF.save(cnmf_obj, str(output_path))
+
+


### PR DESCRIPTION
Create a new function called save_hdf5_file to save the good components for cnmf result as hdf5 file each time the user clicked the "save_to_item" buttom in the eval_gui