### PR TITLE
adding idx_component functionality to reconstructed movie extension

### DIFF
--- a/mesmerize_core/caiman_extensions/cnmf.py
+++ b/mesmerize_core/caiman_extensions/cnmf.py
@@ -219,6 +219,7 @@ class CNMFExtensions:
     def get_reconstructed_movie(
         self,
         ixs_frames: Optional[Union[Tuple[int, int], int]] = None,
+        idx_components: np.ndarray = None,
         add_background: bool = True,
     ) -> np.ndarray:
         """
@@ -241,14 +242,17 @@ class CNMFExtensions:
         """
         cnmf_obj = self.get_output()
 
+        if idx_components is None:
+            idx_components = np.arange(cnmf_obj.estimates.A.shape[1])
+
         if ixs_frames is None:
             ixs_frames = (0, cnmf_obj.estimates.C.shape[1])
 
         if isinstance(ixs_frames, int):
             ixs_frames = (ixs_frames, ixs_frames + 1)
 
-        dn = cnmf_obj.estimates.A.dot(
-            cnmf_obj.estimates.C[:, ixs_frames[0] : ixs_frames[1]]
+        dn = cnmf_obj.estimates.A[:,idx_components].dot(
+            cnmf_obj.estimates.C[idx_components, ixs_frames[0] : ixs_frames[1]]
         )
 
         if add_background:


### PR DESCRIPTION
should allow for a user to pass "good" components to reconstructed movie in order to get certain components for reconstruction