### PR TITLE
splitting reconstructed movie into two functions

### DIFF
--- a/mesmerize_core/caiman_extensions/cnmf.py
+++ b/mesmerize_core/caiman_extensions/cnmf.py
@@ -306,20 +306,6 @@ class CNMFExtensions:
             shape is [n_frames, x_pixels, y_pixels]
         """
 
-        # if ixs_frames is None:
-        #     ixs_frames = (0, self.get_input_memmap().shape[0])
-        #
-        # if isinstance(ixs_frames, int):
-        #     ixs_frames = (ixs_frames, ixs_frames + 1)
-        #
-        # raw_movie = self.get_input_memmap()
-        #
-        # reconstructed_movie = self.get_reconstructed_movie(ixs_frames, True)
-        #
-        # residuals = raw_movie[np.arange(*ixs_frames)] - reconstructed_movie
-
-        ##
-
         cnmf_obj = self.get_output()
 
         if ixs_frames is None:
@@ -332,20 +318,14 @@ class CNMFExtensions:
 
         reconstructed_movie = self.get_reconstructed_movie(ixs_frames)
 
-        background = cnmf_obj.estimates.b.dot(
-            cnmf_obj.estimates.f[:, ixs_frames[0]: ixs_frames[1]]
-        )
+        background = self.get_reconstructed_background(ixs_frames)
 
-        cnmf_obj.estimates.b.dot(
-            cnmf_obj.estimates.f[:, ixs_frames[0]: ixs_frames[1]]
-        )
+        # print(background.shape)
+        # print(raw_movie.shape)
+        # print(reconstructed_movie.shape)
 
-        print(background.shape)
-        print(raw_movie.shape)
-        print(reconstructed_movie.shape)
+        residuals = raw_movie[np.arange(*ixs_frames)] - reconstructed_movie - background
 
-        # residuals = raw_movie[np.arange(*ixs_frames)] - reconstructed_movie - background
+        return residuals.reshape(cnmf_obj.dims + (-1,), order="F").transpose([2, 0, 1])
 
-        # return residuals.reshape(cnmf_obj.dims + (-1,), order="F").transpose([2, 0, 1])
-
-        return
+        #return

--- a/mesmerize_core/caiman_extensions/cnmf.py
+++ b/mesmerize_core/caiman_extensions/cnmf.py
@@ -320,12 +320,6 @@ class CNMFExtensions:
 
         background = self.get_reconstructed_background(ixs_frames)
 
-        # print(background.shape)
-        # print(raw_movie.shape)
-        # print(reconstructed_movie.shape)
-
         residuals = raw_movie[np.arange(*ixs_frames)] - reconstructed_movie - background
 
         return residuals.reshape(cnmf_obj.dims + (-1,), order="F").transpose([2, 0, 1])
-
-        #return

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -542,7 +542,7 @@ def test_cnmf():
     )
 
     # test to check get_reconstructed_movie()
-    cnmf_reconstructed_movie = df.iloc[-1].cnmf.get_reconstructed_movie()
+    cnmf_reconstructed_movie = df.iloc[-1].cnmf.get_reconstructed_movie() + df.iloc[-1].cnmf.get_reconstructed_background()
     cnmf_reconstructed_movie_actual = numpy.load(
         ground_truths_dir.joinpath("cnmf", "reconstructed_movie.npy")
     )
@@ -621,7 +621,7 @@ def test_cnmf():
     )
 
     # test to check ixs components for cnmf.get_reconstructed_movie()
-    ixs_reconstructed_movie = df.iloc[-1].cnmf.get_reconstructed_movie(ixs_components)
+    ixs_reconstructed_movie = df.iloc[-1].cnmf.get_reconstructed_movie(ixs_components) + df.iloc[-1].cnmf.get_reconstructed_background(ixs_components)
     ixs_reconstructed_movie_actual = numpy.load(
         ground_truths_dir.joinpath("cnmf", "cnmf_ixs", "ixs_reconstructed_movie.npy"),
         allow_pickle=True,
@@ -906,7 +906,7 @@ def test_cnmfe():
     )
 
     # test to check get_reconstructed_movie()
-    cnmfe_reconstructed_movie = df.iloc[-1].cnmf.get_reconstructed_movie()
+    cnmfe_reconstructed_movie = df.iloc[-1].cnmf.get_reconstructed_movie() + df.iloc[-1].cnmf.get_reconstructed_background()
     cnmfe_reconstructed_movie_actual = numpy.load(
         ground_truths_dir.joinpath("cnmfe_full", "cnmfe_reconstructed_movie.npy")
     )
@@ -963,7 +963,7 @@ def test_cnmfe():
     )
 
     # test to check ixs components for cnmf.get_reconstructed_movie()
-    ixs_reconstructed_movie = df.iloc[-1].cnmf.get_reconstructed_movie(ixs_components)
+    ixs_reconstructed_movie = df.iloc[-1].cnmf.get_reconstructed_movie(ixs_components) + df.iloc[-1].cnmf.get_reconstructed_background(ixs_components)
     ixs_reconstructed_movie_actual = numpy.load(
         ground_truths_dir.joinpath(
             "cnmfe_full", "cnmfe_ixs", "ixs_reconstructed_movie.npy"


### PR DESCRIPTION
cnmf extension for getting reconstructed movie is now two separate functions

```get_reconstructed_movie()``` only returns (A x C)

```get_reconstructed_background()``` only returns (b x f)

in order to get reconstructed movie as before, using kwarg arg ```background_bool = True"```, would need to simply call both ```get_reconstructed_movie()``` and ```get_reconstructed_background()``` and then add them together!