### PR TITLE
caiman extension to get input movie using pims or caiman.load_memmap

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,5 @@ matplotlib
 click
 psutil
 PyQt5
+pims
+


### PR DESCRIPTION
addressing #52 

should probably also add hdf5

@ArjunPutcha thoughts? I think it's worth having `pims` as a dependency since lots of people use tiff input files. 