### PR TITLE
creating cache for faster access to results of previous cnmf extension calls 

### DIFF
--- a/mesmerize_core/caiman_extensions/cache.py
+++ b/mesmerize_core/caiman_extensions/cache.py
@@ -68,7 +68,7 @@ class Cache:
         for i in range(len(self.cache.index)):
             if isinstance(self.cache.iloc[i, 4], np.ndarray):
                 cache_size += self.cache.iloc[i, 4].data.nbytes
-            elif isinstance(self.cache.iloc[i, 4], tuple):
+            elif isinstance(self.cache.iloc[i, 4], (tuple, list)):
                 for lists in self.cache.iloc[i, 4]:
                     for array in lists:
                         cache_size += array.data.nbytes

--- a/mesmerize_core/caiman_extensions/cache.py
+++ b/mesmerize_core/caiman_extensions/cache.py
@@ -4,14 +4,14 @@ import time
 import numpy as np
 
 
-def check_kwarg_equality(kwargs, cache_kwargs):
-    if not type(kwargs) == type(cache_kwargs):
+def check_arg_equality(args, cache_args):
+    if not type(args) == type(cache_args):
         return False
 
-    if isinstance(cache_kwargs, np.ndarray):
-        return np.array_equal(cache_kwargs, kwargs)
+    if isinstance(cache_args, np.ndarray):
+        return np.array_equal(cache_args, args)
     else:
-        return cache_kwargs == kwargs
+        return cache_args == args
 
 
 class Cache:
@@ -41,7 +41,7 @@ class Cache:
 
             # checking to see if there is a cache hit
             for i in range(len(self.cache.index)):
-                if self.cache.iloc[i, 0] == instance._series['uuid'] and self.cache.iloc[i, 1] == func.__name__  and self.cache.iloc[i, 2] == args and check_kwarg_equality(kwargs, self.cache.iloc[i, 3]):
+                if self.cache.iloc[i, 0] == instance._series['uuid'] and self.cache.iloc[i, 1] == func.__name__ and check_arg_equality(args, self.cache.iloc[i, 2]) and check_arg_equality(kwargs, self.cache.iloc[i, 3]):
                     self.cache.iloc[i, 5] = time.time()
                     return_val = self.cache.iloc[i, 4]
                     return self.cache.iloc[i, 4]

--- a/mesmerize_core/caiman_extensions/cache.py
+++ b/mesmerize_core/caiman_extensions/cache.py
@@ -2,8 +2,9 @@ from functools import wraps
 import pandas as pd
 import time
 
+
 class Cache:
-    def __init__(self, cache_size=3):
+    def __init__(self, cache_size=10):
         self.cache = pd.DataFrame(data=None, columns=['function', 'args', 'kwargs', 'return_val', 'time_stamp'])
         self.cache_size = cache_size
 
@@ -20,12 +21,12 @@ class Cache:
 
             # checking to see if there is a cache hit
             for i in range(len(self.cache.index)):
-                if self.cache.iloc[i, 0] == func.__name__ and self.cache.iloc[i, 1] == args and self.cache.iloc[
-                    i, 2] == kwargs:
+                if self.cache.iloc[i, 0] == func.__name__ and self.cache.iloc[i, 1] == args and self.cache.iloc[i, 2] == kwargs:
                     self.cache.iloc[i, 4] = time.time()
                     return self.cache.iloc[i, 3]
 
-            # no cache hit, must check cache limit, and if limit is going to be exceeded...remove least recently used and add new entry
+            # no cache hit, must check cache limit, and if limit is going to be exceeded...remove least recently used
+            # and add new entry
             if len(self.cache.index) == self.cache_size:
                 self.cache.drop(index=self.cache.sort_values(by=['time_stamp'], ascending=False).index[-1], axis=0,
                                 inplace=True)
@@ -38,6 +39,3 @@ class Cache:
             return func(*args, **kwargs)
 
         return _use_cache
-
-
-cache = Cache()

--- a/mesmerize_core/caiman_extensions/cache.py
+++ b/mesmerize_core/caiman_extensions/cache.py
@@ -39,8 +39,7 @@ class Cache:
         if cache_size is None:
             self.size = 1
             self.storage_type = 'RAM'
-
-        if isinstance(cache_size, int):
+        elif isinstance(cache_size, int):
             self.storage_type = 'ITEMS'
             self.size = cache_size
         else:

--- a/mesmerize_core/caiman_extensions/cache.py
+++ b/mesmerize_core/caiman_extensions/cache.py
@@ -49,9 +49,6 @@ class Cache:
         self.set_maxsize(cache_size)
 
     def get_cache(self):
-        print(self.cache)
-
-    def get_cache2(self):
         return self.cache
 
     def clear_cache(self):
@@ -73,7 +70,7 @@ class Cache:
             self.size = max_size
 
     def _get_cache_size_bytes(self):
-        """Returns in GiB or MB"""
+        """Returns in bytes"""
         cache_size = 0
         for i in range(len(self.cache.index)):
             if isinstance(self.cache.iloc[i, 4], np.ndarray):
@@ -147,7 +144,9 @@ class Cache:
                     return_val,
                     time.time(),
                 ]
-                return _return_wrapper(self.cache.iloc[len(self.cache.index) - 1, 4], copy_bool=return_copy)
+                return _return_wrapper(
+                    self.cache.iloc[len(self.cache.index) - 1, 4], copy_bool=return_copy
+                )
             # if memory type is 'RAM': add new item and then remove least recently used items until cache is under correct size again
             elif self.storage_type == "RAM":
                 while self._get_cache_size_bytes() > self.size:

--- a/mesmerize_core/caiman_extensions/cache.py
+++ b/mesmerize_core/caiman_extensions/cache.py
@@ -5,7 +5,7 @@ import time
 
 class Cache:
     def __init__(self, cache_size=10):
-        self.cache = pd.DataFrame(data=None, columns=['function', 'args', 'kwargs', 'return_val', 'time_stamp'])
+        self.cache = pd.DataFrame(data=None, columns=['uuid', 'function', 'args', 'kwargs', 'return_val', 'time_stamp'])
         self.cache_size = cache_size
 
     def get_cache(self):
@@ -22,21 +22,18 @@ class Cache:
         @wraps(func)
         def _use_cache(instance, *args, **kwargs):
 
-            print(instance)
-            print(args, kwargs)
-
             # if cache is empty, will always be a cache miss
             if len(self.cache.index) == 0:
                 return_val = func(instance, *args, **kwargs)
-                self.cache.loc[len(self.cache.index)] = [func.__name__, args, kwargs, return_val, time.time()]
+                self.cache.loc[len(self.cache.index)] = [instance._series['uuid'], func.__name__, args, kwargs, return_val, time.time()]
 
             # checking to see if there is a cache hit
             for i in range(len(self.cache.index)):
-                if self.cache.iloc[i, 0] == func.__name__ and self.cache.iloc[i, 1] == args and self.cache.iloc[
-                    i, 2] == kwargs:
-                    self.cache.iloc[i, 4] = time.time()
-                    return_val = self.cache.iloc[i, 3]
-                    return self.cache.iloc[i, 3]
+                if self.cache.iloc[i, 0] == instance._series['uuid'] and self.cache.iloc[i, 1] == func.__name__ and self.cache.iloc[i, 2] == args and self.cache.iloc[
+                    i, 3] == kwargs:
+                    self.cache.iloc[i, 5] = time.time()
+                    return_val = self.cache.iloc[i, 4]
+                    return self.cache.iloc[i, 4]
 
             # no cache hit, must check cache limit, and if limit is going to be exceeded...remove least recently used and add new entry
             if len(self.cache.index) == self.cache_size:
@@ -44,11 +41,11 @@ class Cache:
                 self.cache.drop(index=self.cache.sort_values(by=['time_stamp'], ascending=False).index[-1], axis=0,
                                 inplace=True)
                 self.cache = self.cache.reset_index(drop=True)
-                self.cache.loc[len(self.cache.index)] = [func.__name__, args, kwargs, return_val, time.time()]
-                return self.cache.iloc[len(self.cache.index) - 1, 3]
+                self.cache.loc[len(self.cache.index)] = [instance._series['uuid'], func.__name__, args, kwargs, return_val, time.time()]
+                return self.cache.iloc[len(self.cache.index) - 1, 4]
             else:
                 return_val = func(instance, *args, **kwargs)
-                self.cache.loc[len(self.cache.index)] = [func.__name__, args, kwargs, return_val, time.time()]
+                self.cache.loc[len(self.cache.index)] = [instance._series['uuid'], func.__name__, args, kwargs, return_val, time.time()]
 
             return return_val
 

--- a/mesmerize_core/caiman_extensions/cache.py
+++ b/mesmerize_core/caiman_extensions/cache.py
@@ -99,6 +99,10 @@ class Cache:
             else:
                 return_copy = True
 
+            if self.size == 0:
+                self.clear_cache()
+                return _return_wrapper(func(instance, *args, **kwargs), return_copy)
+
             # if cache is empty, will always be a cache miss
             if len(self.cache.index) == 0:
                 return_val = func(instance, *args, **kwargs)

--- a/mesmerize_core/caiman_extensions/cache.py
+++ b/mesmerize_core/caiman_extensions/cache.py
@@ -4,19 +4,32 @@ import time
 import numpy as np
 
 
-def check_arg_equality(args, cache_args):
+def _check_arg_equality(args, cache_args):
     if not type(args) == type(cache_args):
         return False
-
     if isinstance(cache_args, np.ndarray):
         return np.array_equal(cache_args, args)
     else:
         return cache_args == args
 
 
+def _check_args_equality(args, cache_args):
+    equality = list()
+    if isinstance(args, tuple):
+        for arg, cache_arg in zip(args, cache_args):
+            equality.append(_check_arg_equality(arg, cache_arg))
+    else:
+        for k in args.keys():
+            equality.append(_check_arg_equality(args[k], cache_args[k]))
+    return all(equality)
+
+
 class Cache:
     def __init__(self, cache_size=10):
-        self.cache = pd.DataFrame(data=None, columns=['uuid', 'function', 'args', 'kwargs', 'return_val', 'time_stamp'])
+        self.cache = pd.DataFrame(
+            data=None,
+            columns=["uuid", "function", "args", "kwargs", "return_val", "time_stamp"],
+        )
         self.cache_size = cache_size
 
     def get_cache(self):
@@ -36,12 +49,23 @@ class Cache:
             # if cache is empty, will always be a cache miss
             if len(self.cache.index) == 0:
                 return_val = func(instance, *args, **kwargs)
-                self.cache.loc[len(self.cache.index)] = [instance._series['uuid'], func.__name__, args, kwargs,
-                                                         return_val, time.time()]
+                self.cache.loc[len(self.cache.index)] = [
+                    instance._series["uuid"],
+                    func.__name__,
+                    args,
+                    kwargs,
+                    return_val,
+                    time.time(),
+                ]
 
             # checking to see if there is a cache hit
             for i in range(len(self.cache.index)):
-                if self.cache.iloc[i, 0] == instance._series['uuid'] and self.cache.iloc[i, 1] == func.__name__ and check_arg_equality(args, self.cache.iloc[i, 2]) and check_arg_equality(kwargs, self.cache.iloc[i, 3]):
+                if (
+                    self.cache.iloc[i, 0] == instance._series["uuid"]
+                    and self.cache.iloc[i, 1] == func.__name__
+                    and _check_args_equality(args, self.cache.iloc[i, 2])
+                    and _check_arg_equality(kwargs, self.cache.iloc[i, 3])
+                ):
                     self.cache.iloc[i, 5] = time.time()
                     return_val = self.cache.iloc[i, 4]
                     return self.cache.iloc[i, 4]
@@ -49,18 +73,34 @@ class Cache:
             # no cache hit, must check cache limit, and if limit is going to be exceeded...remove least recently used and add new entry
             if len(self.cache.index) == self.cache_size:
                 return_val = func(instance, *args, **kwargs)
-                self.cache.drop(index=self.cache.sort_values(by=['time_stamp'], ascending=False).index[-1], axis=0,
-                                inplace=True)
+                self.cache.drop(
+                    index=self.cache.sort_values(
+                        by=["time_stamp"], ascending=False
+                    ).index[-1],
+                    axis=0,
+                    inplace=True,
+                )
                 self.cache = self.cache.reset_index(drop=True)
-                self.cache.loc[len(self.cache.index)] = [instance._series['uuid'], func.__name__, args, kwargs, return_val,
-                                                         time.time()]
+                self.cache.loc[len(self.cache.index)] = [
+                    instance._series["uuid"],
+                    func.__name__,
+                    args,
+                    kwargs,
+                    return_val,
+                    time.time(),
+                ]
                 return self.cache.iloc[len(self.cache.index) - 1, 4]
             else:
                 return_val = func(instance, *args, **kwargs)
-                self.cache.loc[len(self.cache.index)] = [instance._series['uuid'], func.__name__, args, kwargs, return_val,
-                                                         time.time()]
+                self.cache.loc[len(self.cache.index)] = [
+                    instance._series["uuid"],
+                    func.__name__,
+                    args,
+                    kwargs,
+                    return_val,
+                    time.time(),
+                ]
 
             return return_val
 
         return _use_cache
-

--- a/mesmerize_core/caiman_extensions/cache.py
+++ b/mesmerize_core/caiman_extensions/cache.py
@@ -5,67 +5,51 @@ import time
 
 class Cache:
     def __init__(self, cache_size=10):
-        self.cache = pd.DataFrame(
-            data=None,
-            columns=["function", "args", "kwargs", "return_val", "time_stamp"],
-        )
+        self.cache = pd.DataFrame(data=None, columns=['function', 'args', 'kwargs', 'return_val', 'time_stamp'])
         self.cache_size = cache_size
 
     def get_cache(self):
         print(self.cache)
 
+    def clear_cache(self):
+        while len(self.cache.index) != 0:
+            self.cache.drop(index=self.cache.index[-1], axis=0, inplace=True)
+
+    def set_maxsize(self, max_size: int):
+        self.cache_size = max_size
+
     def use_cache(self, func):
         @wraps(func)
-        def _use_cache(*args, **kwargs):
+        def _use_cache(instance, *args, **kwargs):
+
+            print(instance)
+            print(args, kwargs)
 
             # if cache is empty, will always be a cache miss
             if len(self.cache.index) == 0:
-                self.cache.loc[len(self.cache.index)] = [
-                    func.__name__,
-                    args,
-                    kwargs,
-                    func(args, kwargs),
-                    time.time(),
-                ]
+                return_val = func(instance, *args, **kwargs)
+                self.cache.loc[len(self.cache.index)] = [func.__name__, args, kwargs, return_val, time.time()]
 
             # checking to see if there is a cache hit
             for i in range(len(self.cache.index)):
-                if (
-                    self.cache.iloc[i, 0] == func.__name__
-                    and self.cache.iloc[i, 1] == args
-                    and self.cache.iloc[i, 2] == kwargs
-                ):
+                if self.cache.iloc[i, 0] == func.__name__ and self.cache.iloc[i, 1] == args and self.cache.iloc[
+                    i, 2] == kwargs:
                     self.cache.iloc[i, 4] = time.time()
+                    return_val = self.cache.iloc[i, 3]
                     return self.cache.iloc[i, 3]
 
-            # no cache hit, must check cache limit, and if limit is going to be exceeded...remove least recently used
-            # and add new entry
+            # no cache hit, must check cache limit, and if limit is going to be exceeded...remove least recently used and add new entry
             if len(self.cache.index) == self.cache_size:
-                self.cache.drop(
-                    index=self.cache.sort_values(
-                        by=["time_stamp"], ascending=False
-                    ).index[-1],
-                    axis=0,
-                    inplace=True,
-                )
+                return_val = func(instance, *args, **kwargs)
+                self.cache.drop(index=self.cache.sort_values(by=['time_stamp'], ascending=False).index[-1], axis=0,
+                                inplace=True)
                 self.cache = self.cache.reset_index(drop=True)
-                self.cache.loc[len(self.cache.index)] = [
-                    func.__name__,
-                    args,
-                    kwargs,
-                    func(args, kwargs),
-                    time.time(),
-                ]
+                self.cache.loc[len(self.cache.index)] = [func.__name__, args, kwargs, return_val, time.time()]
                 return self.cache.iloc[len(self.cache.index) - 1, 3]
             else:
-                self.cache.loc[len(self.cache.index)] = [
-                    func.__name__,
-                    args,
-                    kwargs,
-                    func(args, kwargs),
-                    time.time(),
-                ]
+                return_val = func(instance, *args, **kwargs)
+                self.cache.loc[len(self.cache.index)] = [func.__name__, args, kwargs, return_val, time.time()]
 
-            return func(*args, **kwargs)
+            return return_val
 
         return _use_cache

--- a/mesmerize_core/caiman_extensions/cache.py
+++ b/mesmerize_core/caiman_extensions/cache.py
@@ -57,6 +57,7 @@ class Cache:
                     return_val,
                     time.time(),
                 ]
+                return return_val
 
             # checking to see if there is a cache hit
             for i in range(len(self.cache.index)):

--- a/mesmerize_core/caiman_extensions/cache.py
+++ b/mesmerize_core/caiman_extensions/cache.py
@@ -5,7 +5,10 @@ import time
 
 class Cache:
     def __init__(self, cache_size=10):
-        self.cache = pd.DataFrame(data=None, columns=['function', 'args', 'kwargs', 'return_val', 'time_stamp'])
+        self.cache = pd.DataFrame(
+            data=None,
+            columns=["function", "args", "kwargs", "return_val", "time_stamp"],
+        )
         self.cache_size = cache_size
 
     def get_cache(self):
@@ -17,24 +20,51 @@ class Cache:
 
             # if cache is empty, will always be a cache miss
             if len(self.cache.index) == 0:
-                self.cache.loc[len(self.cache.index)] = [func.__name__, args, kwargs, func(args, kwargs), time.time()]
+                self.cache.loc[len(self.cache.index)] = [
+                    func.__name__,
+                    args,
+                    kwargs,
+                    func(args, kwargs),
+                    time.time(),
+                ]
 
             # checking to see if there is a cache hit
             for i in range(len(self.cache.index)):
-                if self.cache.iloc[i, 0] == func.__name__ and self.cache.iloc[i, 1] == args and self.cache.iloc[i, 2] == kwargs:
+                if (
+                    self.cache.iloc[i, 0] == func.__name__
+                    and self.cache.iloc[i, 1] == args
+                    and self.cache.iloc[i, 2] == kwargs
+                ):
                     self.cache.iloc[i, 4] = time.time()
                     return self.cache.iloc[i, 3]
 
             # no cache hit, must check cache limit, and if limit is going to be exceeded...remove least recently used
             # and add new entry
             if len(self.cache.index) == self.cache_size:
-                self.cache.drop(index=self.cache.sort_values(by=['time_stamp'], ascending=False).index[-1], axis=0,
-                                inplace=True)
+                self.cache.drop(
+                    index=self.cache.sort_values(
+                        by=["time_stamp"], ascending=False
+                    ).index[-1],
+                    axis=0,
+                    inplace=True,
+                )
                 self.cache = self.cache.reset_index(drop=True)
-                self.cache.loc[len(self.cache.index)] = [func.__name__, args, kwargs, func(args, kwargs), time.time()]
+                self.cache.loc[len(self.cache.index)] = [
+                    func.__name__,
+                    args,
+                    kwargs,
+                    func(args, kwargs),
+                    time.time(),
+                ]
                 return self.cache.iloc[len(self.cache.index) - 1, 3]
             else:
-                self.cache.loc[len(self.cache.index)] = [func.__name__, args, kwargs, func(args, kwargs), time.time()]
+                self.cache.loc[len(self.cache.index)] = [
+                    func.__name__,
+                    args,
+                    kwargs,
+                    func(args, kwargs),
+                    time.time(),
+                ]
 
             return func(*args, **kwargs)
 

--- a/mesmerize_core/caiman_extensions/cache.py
+++ b/mesmerize_core/caiman_extensions/cache.py
@@ -36,15 +36,16 @@ class Cache:
             data=None,
             columns=["uuid", "function", "args", "kwargs", "return_val", "time_stamp"],
         )
-        self.size = cache_size
-        if isinstance(cache_size, int):
-            self.storage_type = 'ITEMS'
-        else:
-            self.storage_type = 'RAM'
-
         if cache_size is None:
             self.size = 1
             self.storage_type = 'RAM'
+
+        if isinstance(cache_size, int):
+            self.storage_type = 'ITEMS'
+            self.size = cache_size
+        else:
+            self.storage_type = 'RAM'
+            self.size = int(re.split('[a-zA-Z]', cache_size)[0])
 
     def get_cache(self):
         print(self.cache)
@@ -56,7 +57,7 @@ class Cache:
     def set_maxsize(self, max_size: Union[int, str]):
         if isinstance(max_size, str):
             self.storage_type = 'RAM'
-            self.size = int(re.split('\d+', max_size)[0])
+            self.size = int(re.split('[a-zA-Z]', max_size)[0])
         else:
             self.storage_type = 'ITEMS'
             self.size = max_size

--- a/mesmerize_core/caiman_extensions/cache.py
+++ b/mesmerize_core/caiman_extensions/cache.py
@@ -1,6 +1,17 @@
 from functools import wraps
 import pandas as pd
 import time
+import numpy as np
+
+
+def check_kwarg_equality(kwargs, cache_kwargs):
+    if not type(kwargs) == type(cache_kwargs):
+        return False
+
+    if isinstance(cache_kwargs, np.ndarray):
+        return np.array_equal(cache_kwargs, kwargs)
+    else:
+        return cache_kwargs == kwargs
 
 
 class Cache:
@@ -25,12 +36,12 @@ class Cache:
             # if cache is empty, will always be a cache miss
             if len(self.cache.index) == 0:
                 return_val = func(instance, *args, **kwargs)
-                self.cache.loc[len(self.cache.index)] = [instance._series['uuid'], func.__name__, args, kwargs, return_val, time.time()]
+                self.cache.loc[len(self.cache.index)] = [instance._series['uuid'], func.__name__, args, kwargs,
+                                                         return_val, time.time()]
 
             # checking to see if there is a cache hit
             for i in range(len(self.cache.index)):
-                if self.cache.iloc[i, 0] == instance._series['uuid'] and self.cache.iloc[i, 1] == func.__name__ and self.cache.iloc[i, 2] == args and self.cache.iloc[
-                    i, 3] == kwargs:
+                if self.cache.iloc[i, 0] == instance._series['uuid'] and self.cache.iloc[i, 1] == func.__name__  and self.cache.iloc[i, 2] == args and check_kwarg_equality(kwargs, self.cache.iloc[i, 3]):
                     self.cache.iloc[i, 5] = time.time()
                     return_val = self.cache.iloc[i, 4]
                     return self.cache.iloc[i, 4]
@@ -41,12 +52,15 @@ class Cache:
                 self.cache.drop(index=self.cache.sort_values(by=['time_stamp'], ascending=False).index[-1], axis=0,
                                 inplace=True)
                 self.cache = self.cache.reset_index(drop=True)
-                self.cache.loc[len(self.cache.index)] = [instance._series['uuid'], func.__name__, args, kwargs, return_val, time.time()]
+                self.cache.loc[len(self.cache.index)] = [instance._series['uuid'], func.__name__, args, kwargs, return_val,
+                                                         time.time()]
                 return self.cache.iloc[len(self.cache.index) - 1, 4]
             else:
                 return_val = func(instance, *args, **kwargs)
-                self.cache.loc[len(self.cache.index)] = [instance._series['uuid'], func.__name__, args, kwargs, return_val, time.time()]
+                self.cache.loc[len(self.cache.index)] = [instance._series['uuid'], func.__name__, args, kwargs, return_val,
+                                                         time.time()]
 
             return return_val
 
         return _use_cache
+

--- a/mesmerize_core/caiman_extensions/cache.py
+++ b/mesmerize_core/caiman_extensions/cache.py
@@ -1,0 +1,43 @@
+from functools import wraps
+import pandas as pd
+import time
+
+class Cache:
+    def __init__(self, cache_size=3):
+        self.cache = pd.DataFrame(data=None, columns=['function', 'args', 'kwargs', 'return_val', 'time_stamp'])
+        self.cache_size = cache_size
+
+    def get_cache(self):
+        print(self.cache)
+
+    def use_cache(self, func):
+        @wraps(func)
+        def _use_cache(*args, **kwargs):
+
+            # if cache is empty, will always be a cache miss
+            if len(self.cache.index) == 0:
+                self.cache.loc[len(self.cache.index)] = [func.__name__, args, kwargs, func(args, kwargs), time.time()]
+
+            # checking to see if there is a cache hit
+            for i in range(len(self.cache.index)):
+                if self.cache.iloc[i, 0] == func.__name__ and self.cache.iloc[i, 1] == args and self.cache.iloc[
+                    i, 2] == kwargs:
+                    self.cache.iloc[i, 4] = time.time()
+                    return self.cache.iloc[i, 3]
+
+            # no cache hit, must check cache limit, and if limit is going to be exceeded...remove least recently used and add new entry
+            if len(self.cache.index) == self.cache_size:
+                self.cache.drop(index=self.cache.sort_values(by=['time_stamp'], ascending=False).index[-1], axis=0,
+                                inplace=True)
+                self.cache = self.cache.reset_index(drop=True)
+                self.cache.loc[len(self.cache.index)] = [func.__name__, args, kwargs, func(args, kwargs), time.time()]
+                return self.cache.iloc[len(self.cache.index) - 1, 3]
+            else:
+                self.cache.loc[len(self.cache.index)] = [func.__name__, args, kwargs, func(args, kwargs), time.time()]
+
+            return func(*args, **kwargs)
+
+        return _use_cache
+
+
+cache = Cache()

--- a/mesmerize_core/caiman_extensions/cache.py
+++ b/mesmerize_core/caiman_extensions/cache.py
@@ -71,7 +71,7 @@ class Cache:
             elif isinstance(self.cache.iloc[i, 4], Path):
                 cache_size += 0
             elif isinstance(self.cache.iloc[i, 4], CNMF):
-                cache_size += sys.getsizeof(self.cache.iloc[i,4].estimates)
+                cache_size += sys.getsizeof(self.cache.iloc[i, 4].estimates)
             else:
                 cache_size += sys.getsizeof(self.cache.iloc[i, 4])
 
@@ -111,66 +111,36 @@ class Cache:
 
             # no cache hit, must check cache limit, and if limit is going to be exceeded...remove least recently used and add new entry
             # check which type of memory
-            if self.storage_type == 'ITEMS':
-                if len(self.cache.index) == self.size:
-                    return_val = func(instance, *args, **kwargs)
-                    self.cache.drop(
-                        index=self.cache.sort_values(
-                            by=["time_stamp"], ascending=False
-                        ).index[-1],
-                        axis=0,
-                        inplace=True,
-                    )
-                    self.cache = self.cache.reset_index(drop=True)
-                    self.cache.loc[len(self.cache.index)] = [
-                        instance._series["uuid"],
-                        func.__name__,
-                        args,
-                        kwargs,
-                        return_val,
-                        time.time(),
-                    ]
-                    return self.cache.iloc[len(self.cache.index) - 1, 4]
-                else:
-                    return_val = func(instance, *args, **kwargs)
-                    self.cache.loc[len(self.cache.index)] = [
-                        instance._series["uuid"],
-                        func.__name__,
-                        args,
-                        kwargs,
-                        return_val,
-                        time.time(),
-                    ]
-            elif self.storage_type == 'RAM':
-                if self._get_cache_size_bytes() >= self.size:
-                    return_val = func(instance, *args, **kwargs)
-                    self.cache.drop(
-                        index=self.cache.sort_values(
-                            by=["time_stamp"], ascending=False
-                        ).index[-1],
-                        axis=0,
-                        inplace=True,
-                    )
-                    self.cache = self.cache.reset_index(drop=True)
-                    self.cache.loc[len(self.cache.index)] = [
-                        instance._series["uuid"],
-                        func.__name__,
-                        args,
-                        kwargs,
-                        return_val,
-                        time.time(),
-                    ]
-                    return self.cache.iloc[len(self.cache.index) - 1, 4]
-                else:
-                    return_val = func(instance, *args, **kwargs)
-                    self.cache.loc[len(self.cache.index)] = [
-                        instance._series["uuid"],
-                        func.__name__,
-                        args,
-                        kwargs,
-                        return_val,
-                        time.time(),
-                    ]
+            if (self.storage_type == 'ITEMS' and len(self.cache.index) == self.size) or (self.storage_type == 'RAM' and self._get_cache_size_bytes() >= self.size):
+                return_val = func(instance, *args, **kwargs)
+                self.cache.drop(
+                    index=self.cache.sort_values(
+                        by=["time_stamp"], ascending=False
+                    ).index[-1],
+                    axis=0,
+                    inplace=True,
+                )
+                self.cache = self.cache.reset_index(drop=True)
+                self.cache.loc[len(self.cache.index)] = [
+                    instance._series["uuid"],
+                    func.__name__,
+                    args,
+                    kwargs,
+                    return_val,
+                    time.time(),
+                ]
+                return self.cache.iloc[len(self.cache.index) - 1, 4]
+
+            else:
+                return_val = func(instance, *args, **kwargs)
+                self.cache.loc[len(self.cache.index)] = [
+                    instance._series["uuid"],
+                    func.__name__,
+                    args,
+                    kwargs,
+                    return_val,
+                    time.time(),
+                ]
 
             return return_val
 

--- a/mesmerize_core/caiman_extensions/cache.py
+++ b/mesmerize_core/caiman_extensions/cache.py
@@ -94,8 +94,8 @@ class Cache:
     def use_cache(self, func):
         @wraps(func)
         def _use_cache(instance, *args, **kwargs):
-            if "copy" in kwargs.keys():
-                return_copy = kwargs["copy"]
+            if "return_copy" in kwargs.keys():
+                return_copy = kwargs["return_copy"]
             else:
                 return_copy = True
 

--- a/mesmerize_core/caiman_extensions/cnmf.py
+++ b/mesmerize_core/caiman_extensions/cnmf.py
@@ -74,7 +74,7 @@ class CNMFExtensions:
 
     @validate("cnmf")
     @cache.use_cache
-    def get_output(self) -> CNMF:
+    def get_output(self, copy=True) -> CNMF:
         """
         Returns
         -------
@@ -89,7 +89,7 @@ class CNMFExtensions:
     @validate("cnmf")
     @cache.use_cache
     def get_spatial_masks(
-        self, ixs_components: Optional[np.ndarray] = None, threshold: float = 0.01
+        self, ixs_components: Optional[np.ndarray] = None, threshold: float = 0.01, copy=True
     ) -> np.ndarray:
         """
         Get binary masks of the spatial components at the given `ixs`
@@ -156,7 +156,7 @@ class CNMFExtensions:
     @validate("cnmf")
     @cache.use_cache
     def get_spatial_contours(
-        self, ixs_components: Optional[np.ndarray] = None
+        self, ixs_components: Optional[np.ndarray] = None, copy=True
     ) -> Tuple[List[np.ndarray], List[np.ndarray]]:
         """
         Get the contour and center of mass for each spatial footprint
@@ -190,7 +190,7 @@ class CNMFExtensions:
     @validate("cnmf")
     @cache.use_cache
     def get_temporal_components(
-        self, ixs_components: Optional[np.ndarray] = None, add_background: bool = False
+        self, ixs_components: Optional[np.ndarray] = None, add_background: bool = False, copy=True
     ) -> np.ndarray:
         """
         Get the temporal components for this CNMF item

--- a/mesmerize_core/caiman_extensions/cnmf.py
+++ b/mesmerize_core/caiman_extensions/cnmf.py
@@ -25,7 +25,6 @@ class CNMFExtensions:
         self._series = s
 
     @validate("cnmf")
-    @cache.use_cache
     def get_cnmf_memmap(self) -> np.ndarray:
         """
         Get the CNMF memmap
@@ -41,7 +40,6 @@ class CNMFExtensions:
         images = np.reshape(Yr.T, [T] + list(dims), order="F")
         return images
 
-    @cache.use_cache
     def get_input_memmap(self) -> np.ndarray:
         """
         Return the F-order memmap if the input to the
@@ -65,7 +63,6 @@ class CNMFExtensions:
 
     # TODO: Cache this globally so that a common upper cache limit is valid for ALL batch items
     @validate("cnmf")
-    @cache.use_cache
     def get_output_path(self) -> Path:
         """
         Returns

--- a/mesmerize_core/caiman_extensions/cnmf.py
+++ b/mesmerize_core/caiman_extensions/cnmf.py
@@ -259,7 +259,7 @@ class CNMFExtensions:
             ixs_frames = (ixs_frames, ixs_frames + 1)
 
         dn = cnmf_obj.estimates.A[:, idx_components].dot(
-            cnmf_obj.estimates.C[idx_components, ixs_frames[0] : ixs_frames[1]]
+            cnmf_obj.estimates.C[idx_components, ixs_frames[0]: ixs_frames[1]]
         )
 
         if add_background:

--- a/mesmerize_core/caiman_extensions/cnmf.py
+++ b/mesmerize_core/caiman_extensions/cnmf.py
@@ -74,7 +74,7 @@ class CNMFExtensions:
 
     @validate("cnmf")
     @cache.use_cache
-    def get_output(self, copy=True) -> CNMF:
+    def get_output(self, return_copy=True) -> CNMF:
         """
         Returns
         -------
@@ -89,7 +89,7 @@ class CNMFExtensions:
     @validate("cnmf")
     @cache.use_cache
     def get_spatial_masks(
-        self, ixs_components: Optional[np.ndarray] = None, threshold: float = 0.01, copy=True
+        self, ixs_components: Optional[np.ndarray] = None, threshold: float = 0.01, return_copy=True
     ) -> np.ndarray:
         """
         Get binary masks of the spatial components at the given `ixs`
@@ -156,7 +156,7 @@ class CNMFExtensions:
     @validate("cnmf")
     @cache.use_cache
     def get_spatial_contours(
-        self, ixs_components: Optional[np.ndarray] = None, copy=True
+        self, ixs_components: Optional[np.ndarray] = None, return_copy=True
     ) -> Tuple[List[np.ndarray], List[np.ndarray]]:
         """
         Get the contour and center of mass for each spatial footprint
@@ -190,7 +190,7 @@ class CNMFExtensions:
     @validate("cnmf")
     @cache.use_cache
     def get_temporal_components(
-        self, ixs_components: Optional[np.ndarray] = None, add_background: bool = False, copy=True
+        self, ixs_components: Optional[np.ndarray] = None, add_background: bool = False, return_copy=True
     ) -> np.ndarray:
         """
         Get the temporal components for this CNMF item

--- a/mesmerize_core/caiman_extensions/cnmf.py
+++ b/mesmerize_core/caiman_extensions/cnmf.py
@@ -24,6 +24,8 @@ class CNMFExtensions:
     def __init__(self, s: pd.Series):
         self._series = s
 
+    @validate("cnmf")
+    @cache.use_cache
     def get_cnmf_memmap(self) -> np.ndarray:
         """
         Get the CNMF memmap
@@ -39,6 +41,7 @@ class CNMFExtensions:
         images = np.reshape(Yr.T, [T] + list(dims), order="F")
         return images
 
+    @cache.use_cache
     def get_input_memmap(self) -> np.ndarray:
         """
         Return the F-order memmap if the input to the

--- a/mesmerize_core/caiman_extensions/cnmf.py
+++ b/mesmerize_core/caiman_extensions/cnmf.py
@@ -89,7 +89,7 @@ class CNMFExtensions:
     @validate("cnmf")
     @cache.use_cache
     def get_spatial_masks(
-            self, ixs_components: Optional[np.ndarray] = None, threshold: float = 0.01
+        self, ixs_components: Optional[np.ndarray] = None, threshold: float = 0.01
     ) -> np.ndarray:
         """
         Get binary masks of the spatial components at the given `ixs`
@@ -134,7 +134,7 @@ class CNMFExtensions:
     # TODO: Cache this globally so that a common upper cache limit is valid for ALL batch items
     @staticmethod
     def _get_spatial_contours(
-            cnmf_obj: CNMF, ixs_components: Optional[np.ndarray] = None
+        cnmf_obj: CNMF, ixs_components: Optional[np.ndarray] = None
     ):
         if ixs_components is None:
             ixs_components = cnmf_obj.estimates.idx_components
@@ -156,7 +156,7 @@ class CNMFExtensions:
     @validate("cnmf")
     @cache.use_cache
     def get_spatial_contours(
-            self, ixs_components: Optional[np.ndarray] = None
+        self, ixs_components: Optional[np.ndarray] = None
     ) -> Tuple[List[np.ndarray], List[np.ndarray]]:
         """
         Get the contour and center of mass for each spatial footprint
@@ -190,7 +190,7 @@ class CNMFExtensions:
     @validate("cnmf")
     @cache.use_cache
     def get_temporal_components(
-            self, ixs_components: Optional[np.ndarray] = None, add_background: bool = False
+        self, ixs_components: Optional[np.ndarray] = None, add_background: bool = False
     ) -> np.ndarray:
         """
         Get the temporal components for this CNMF item
@@ -224,10 +224,10 @@ class CNMFExtensions:
     # TODO: Cache this globally so that a common upper cache limit is valid for ALL batch items
     @validate("cnmf")
     def get_reconstructed_movie(
-            self,
-            ixs_frames: Optional[Union[Tuple[int, int], int]] = None,
-            idx_components: np.ndarray = None,
-            add_background: bool = True,
+        self,
+        ixs_frames: Optional[Union[Tuple[int, int], int]] = None,
+        idx_components: np.ndarray = None,
+        add_background: bool = True,
     ) -> np.ndarray:
         """
         Return the reconstructed movie, (A * C) + (b * f)
@@ -259,11 +259,11 @@ class CNMFExtensions:
             ixs_frames = (ixs_frames, ixs_frames + 1)
 
         dn = cnmf_obj.estimates.A[:, idx_components].dot(
-            cnmf_obj.estimates.C[idx_components, ixs_frames[0]: ixs_frames[1]]
+            cnmf_obj.estimates.C[idx_components, ixs_frames[0] : ixs_frames[1]]
         )
 
         if add_background:
             dn += cnmf_obj.estimates.b.dot(
-                cnmf_obj.estimates.f[:, ixs_frames[0]: ixs_frames[1]]
+                cnmf_obj.estimates.f[:, ixs_frames[0] : ixs_frames[1]]
             )
         return dn.reshape(cnmf_obj.dims + (-1,), order="F").transpose([2, 0, 1])

--- a/mesmerize_core/caiman_extensions/common.py
+++ b/mesmerize_core/caiman_extensions/common.py
@@ -270,10 +270,10 @@ class CaimanSeriesExtensions:
     def get_input_movie(self) -> Union[np.ndarray, pims.FramesSequence]:
         extension = self.get_input_movie_path().suffixes[-1]
 
-        if extension in ['.tiff', '.tif', '.btf']:
+        if extension in [".tiff", ".tif", ".btf"]:
             return pims.open(str(self.get_input_movie_path()))
 
-        elif extension in ['.mmap', '.memmap']:
+        elif extension in [".mmap", ".memmap"]:
             Yr, dims, T = load_memmap(str(self.get_input_movie_path()))
             return np.reshape(Yr.T, [T] + list(dims), order="F")
 

--- a/mesmerize_core/caiman_extensions/mcorr.py
+++ b/mesmerize_core/caiman_extensions/mcorr.py
@@ -33,7 +33,6 @@ class MCorrExtensions:
         return self._series.paths.resolve(self._series["outputs"]["mcorr-output-path"])
 
     @validate("mcorr")
-    @cache.use_cache
     def get_output(self) -> np.ndarray:
         """
         Get the motion corrected output as a memmaped numpy array, allows fast random-access scrolling.

--- a/mesmerize_core/caiman_extensions/mcorr.py
+++ b/mesmerize_core/caiman_extensions/mcorr.py
@@ -6,6 +6,9 @@ from caiman import load_memmap
 
 from .common import validate
 from typing import *
+from cache import Cache
+
+cache = Cache()
 
 
 @pd.api.extensions.register_series_accessor("mcorr")
@@ -18,6 +21,7 @@ class MCorrExtensions:
         self._series = s
 
     @validate("mcorr")
+    @cache.use_cache
     def get_output_path(self) -> Path:
         """
         Get the path to the motion corrected output memmap file
@@ -30,6 +34,7 @@ class MCorrExtensions:
         return self._series.paths.resolve(self._series["outputs"]["mcorr-output-path"])
 
     @validate("mcorr")
+    @cache.use_cache
     def get_output(self) -> np.ndarray:
         """
         Get the motion corrected output as a memmaped numpy array, allows fast random-access scrolling.
@@ -45,6 +50,7 @@ class MCorrExtensions:
         return mc_movie
 
     @validate("mcorr")
+    @cache.use_cache
     def get_shifts(
         self, pw_rigid: bool = False
     ) -> Tuple[List[np.ndarray], List[np.ndarray]]:

--- a/mesmerize_core/caiman_extensions/mcorr.py
+++ b/mesmerize_core/caiman_extensions/mcorr.py
@@ -21,7 +21,6 @@ class MCorrExtensions:
         self._series = s
 
     @validate("mcorr")
-    @cache.use_cache
     def get_output_path(self) -> Path:
         """
         Get the path to the motion corrected output memmap file

--- a/mesmerize_core/caiman_extensions/mcorr.py
+++ b/mesmerize_core/caiman_extensions/mcorr.py
@@ -6,7 +6,7 @@ from caiman import load_memmap
 
 from .common import validate
 from typing import *
-from cache import Cache
+from .cache import Cache
 
 cache = Cache()
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -633,8 +633,6 @@ def test_cnmf():
         ixs_reconstructed_movie, ixs_reconstructed_movie_actual, rtol=1e2, atol=1e-10
     )
 
-    cnmf.cache.clear_cache()
-
 
 def test_cnmfe():
     set_parent_raw_data_path(vid_dir)
@@ -979,8 +977,6 @@ def test_cnmfe():
         ixs_reconstructed_movie, ixs_reconstructed_movie_actual, rtol=1e2, atol=1e-10
     )
 
-    cnmf.cache.clear_cache()
-
 
 def test_remove_item():
     set_parent_raw_data_path(vid_dir)
@@ -1046,6 +1042,9 @@ def test_remove_item():
 
 
 def test_cache():
+    print("*** Testing cache ***")
+    cnmf.cache.clear_cache()
+
     set_parent_raw_data_path(vid_dir)
     algo = "mcorr"
 
@@ -1100,7 +1099,6 @@ def test_cache():
     )
 
     algo = "cnmf"
-    print("Testing cnmf")
     input_movie_path = df.iloc[-1].mcorr.get_output_path()
     df.caiman.add_item(
         algo=algo,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1268,13 +1268,13 @@ def test_cache():
     
     # test for copy
     # if return_copy=True, then hex id of calls to the same function should be false
+    output = df.iloc[1].cnmf.get_output()
     assert(hex(id(output)) != hex(id(cache.sort_values(by=["time_stamp"], ascending=True).iloc[-1])))
     # if return_copy=False, then hex id of calls to the same function should be true
-    df.iloc[1].cnmf.get_output(return_copy=False)
-    df.iloc[1].cnmf.get_output(return_copy=False)
     output = df.iloc[1].cnmf.get_output(return_copy=False)
     output2 = df.iloc[1].cnmf.get_output(return_copy=False)
     assert(hex(id(output)) == hex(id(output2)))
+    assert(hex(id(cnmf.cache.get_cache().iloc[-1]["return_val"])) == hex(id(output)))
 
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1253,6 +1253,30 @@ def test_cache():
     # checking that the uuid of the output in the cache is the correct uuid of the batch item in the df
     assert(cache.iloc[-1]["uuid"] == df.iloc[-1]["uuid"])
 
+    # call get output from cnmf, check that it is the most recent thing called in the cache
+    df.iloc[1].cnmf.get_output()
+    cnmf_uuid = df.iloc[1]["uuid"]
+    most_recently_called = cache.sort_values(by=["time_stamp"], ascending=True).iloc[-1]
+    cache_uuid = most_recently_called["uuid"]
+    assert(cnmf_uuid == cache_uuid)
+
+    # check to make sure by certain params that it is cnmf vs cnmfe
+    output = df.iloc[1].cnmf.get_output()
+    assert(output.params.patch["low_rank_background"] == True)
+    output2 = df.iloc[-1].cnmf.get_output()
+    assert(output2.params.patch["low_rank_background"] == False)
+    
+    # test for copy
+    # if return_copy=True, then hex id of calls to the same function should be false
+    assert(hex(id(output)) != hex(id(cache.sort_values(by=["time_stamp"], ascending=True).iloc[-1])))
+    # if return_copy=False, then hex id of calls to the same function should be true
+    df.iloc[1].cnmf.get_output(return_copy=False)
+    df.iloc[1].cnmf.get_output(return_copy=False)
+    output = df.iloc[1].cnmf.get_output(return_copy=False)
+    output2 = df.iloc[1].cnmf.get_output(return_copy=False)
+    assert(hex(id(output)) == hex(id(output2)))
+
+
 
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -633,6 +633,8 @@ def test_cnmf():
         ixs_reconstructed_movie, ixs_reconstructed_movie_actual, rtol=1e2, atol=1e-10
     )
 
+    cnmf.cache.clear_cache()
+
 
 def test_cnmfe():
     set_parent_raw_data_path(vid_dir)
@@ -976,6 +978,8 @@ def test_cnmfe():
     numpy.testing.assert_allclose(
         ixs_reconstructed_movie, ixs_reconstructed_movie_actual, rtol=1e2, atol=1e-10
     )
+
+    cnmf.cache.clear_cache()
 
 
 def test_remove_item():

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1183,9 +1183,17 @@ def test_cache():
     assert (len(cnmf.cache.get_cache().index) == 0)
 
     cnmf.cache.set_maxsize(0)
+    start = time.time()
     df.iloc[-1].cnmf.get_output()
-    print(cnmf.cache.get_cache())
-    # assert (len(cnmf.cache.get_cache().index) == 0)
+    end = time.time()
+    assert (len(cnmf.cache.get_cache().index) == 0)
+
+    start2 = time.time()
+    df.iloc[-1].cnmf.get_output()
+    end2 = time.time()
+    assert (len(cnmf.cache.get_cache().index) == 0)
+    assert(abs((end-start)-(end2-start2)) < 0.01)
+
 
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -169,34 +169,34 @@ def test_mcorr():
 
     # test that batch path is propagated to pd.Series
     assert (
-        df.attrs["batch_path"]
-        == df.paths.get_batch_path()
-        == df.iloc[-1].paths.get_batch_path()
-        == df.iloc[-1].attrs["batch_path"]
+            df.attrs["batch_path"]
+            == df.paths.get_batch_path()
+            == df.iloc[-1].paths.get_batch_path()
+            == df.iloc[-1].attrs["batch_path"]
     )
 
     # test that path resolve works for parent_raw_dir
     rel_input_movie_path = input_movie_path.relative_to(vid_dir)
     assert (
-        df.paths.resolve(rel_input_movie_path)
-        == df.iloc[-1].paths.resolve(rel_input_movie_path)
-        == input_movie_path
+            df.paths.resolve(rel_input_movie_path)
+            == df.iloc[-1].paths.resolve(rel_input_movie_path)
+            == input_movie_path
     )
     # test that path splitting works for parent_raw_dir
     split = (vid_dir, input_movie_path.relative_to(vid_dir))
     assert (
-        df.paths.split(input_movie_path)
-        == df.iloc[-1].paths.split(input_movie_path)
-        == split
+            df.paths.split(input_movie_path)
+            == df.iloc[-1].paths.split(input_movie_path)
+            == split
     )
     # test that the input_movie_path in the DataFrame rows are relative
     assert Path(df.iloc[-1]["input_movie_path"]) == split[1]
 
     assert (
-        get_full_raw_data_path(df.iloc[-1]["input_movie_path"])
-        == vid_dir.joinpath(f"{algo}.tif")
-        == vid_dir.joinpath(df.iloc[-1]["input_movie_path"])
-        == df.paths.resolve(df.iloc[-1]["input_movie_path"])
+            get_full_raw_data_path(df.iloc[-1]["input_movie_path"])
+            == vid_dir.joinpath(f"{algo}.tif")
+            == vid_dir.joinpath(df.iloc[-1]["input_movie_path"])
+            == df.paths.resolve(df.iloc[-1]["input_movie_path"])
     )
 
     process = df.iloc[-1].caiman.run()
@@ -219,76 +219,76 @@ def test_mcorr():
     )
     rel_mcorr_memmap_path = mcorr_memmap_path.relative_to(batch_dir)
     assert (
-        df.paths.resolve(rel_mcorr_memmap_path)
-        == df.iloc[-1].paths.resolve(rel_mcorr_memmap_path)
-        == mcorr_memmap_path
+            df.paths.resolve(rel_mcorr_memmap_path)
+            == df.iloc[-1].paths.resolve(rel_mcorr_memmap_path)
+            == mcorr_memmap_path
     )
     # test that path splitting works for batch_dir
     split = (batch_dir, mcorr_memmap_path.relative_to(batch_dir))
     assert (
-        df.paths.split(mcorr_memmap_path)
-        == df.iloc[-1].paths.split(mcorr_memmap_path)
-        == split
+            df.paths.split(mcorr_memmap_path)
+            == df.iloc[-1].paths.split(mcorr_memmap_path)
+            == split
     )
 
     assert (
-        input_movie_path
-        == df.iloc[-1].caiman.get_input_movie_path()
-        == df.paths.resolve(df.iloc[-1]["input_movie_path"])
+            input_movie_path
+            == df.iloc[-1].caiman.get_input_movie_path()
+            == df.paths.resolve(df.iloc[-1]["input_movie_path"])
     )
 
     # test to check mmap output path
     assert (
-        batch_dir.joinpath(df.iloc[-1]["outputs"]["mcorr-output-path"])
-        == df.paths.resolve(df.iloc[-1]["outputs"]["mcorr-output-path"])
-        == batch_dir.joinpath(
-            str(df.iloc[-1]["uuid"]),
-            f'{df.iloc[-1]["uuid"]}-mcorr_els__d1_60_d2_80_d3_1_order_F_frames_2000_.mmap',
-        )
+            batch_dir.joinpath(df.iloc[-1]["outputs"]["mcorr-output-path"])
+            == df.paths.resolve(df.iloc[-1]["outputs"]["mcorr-output-path"])
+            == batch_dir.joinpath(
+        str(df.iloc[-1]["uuid"]),
+        f'{df.iloc[-1]["uuid"]}-mcorr_els__d1_60_d2_80_d3_1_order_F_frames_2000_.mmap',
+    )
     )
 
     # test to check mean-projection output path
     assert (
-        batch_dir.joinpath(df.iloc[-1]["outputs"]["mean-projection-path"])
-        == df.paths.resolve(df.iloc[-1]["outputs"]["mean-projection-path"])
-        == batch_dir.joinpath(
-            str(df.iloc[-1]["uuid"]), f'{df.iloc[-1]["uuid"]}_mean_projection.npy'
-        )
+            batch_dir.joinpath(df.iloc[-1]["outputs"]["mean-projection-path"])
+            == df.paths.resolve(df.iloc[-1]["outputs"]["mean-projection-path"])
+            == batch_dir.joinpath(
+        str(df.iloc[-1]["uuid"]), f'{df.iloc[-1]["uuid"]}_mean_projection.npy'
+    )
     )
 
     # test to check std-projection output path
     assert (
-        batch_dir.joinpath(df.iloc[-1]["outputs"]["std-projection-path"])
-        == df.paths.resolve(df.iloc[-1]["outputs"]["std-projection-path"])
-        == batch_dir.joinpath(
-            str(df.iloc[-1]["uuid"]), f'{df.iloc[-1]["uuid"]}_std_projection.npy'
-        )
+            batch_dir.joinpath(df.iloc[-1]["outputs"]["std-projection-path"])
+            == df.paths.resolve(df.iloc[-1]["outputs"]["std-projection-path"])
+            == batch_dir.joinpath(
+        str(df.iloc[-1]["uuid"]), f'{df.iloc[-1]["uuid"]}_std_projection.npy'
+    )
     )
 
     # test to check max-projection output path
     assert (
-        batch_dir.joinpath(df.iloc[-1]["outputs"]["max-projection-path"])
-        == df.paths.resolve(df.iloc[-1]["outputs"]["max-projection-path"])
-        == batch_dir.joinpath(
-            str(df.iloc[-1]["uuid"]), f'{df.iloc[-1]["uuid"]}_max_projection.npy'
-        )
+            batch_dir.joinpath(df.iloc[-1]["outputs"]["max-projection-path"])
+            == df.paths.resolve(df.iloc[-1]["outputs"]["max-projection-path"])
+            == batch_dir.joinpath(
+        str(df.iloc[-1]["uuid"]), f'{df.iloc[-1]["uuid"]}_max_projection.npy'
+    )
     )
 
     # test to check correlation image output path
     assert (
-        batch_dir.joinpath(df.iloc[-1]["outputs"]["corr-img-path"])
-        == df.paths.resolve(df.iloc[-1]["outputs"]["corr-img-path"])
-        == batch_dir.joinpath(str(df.iloc[-1]["uuid"]), f'{df.iloc[-1]["uuid"]}_cn.npy')
+            batch_dir.joinpath(df.iloc[-1]["outputs"]["corr-img-path"])
+            == df.paths.resolve(df.iloc[-1]["outputs"]["corr-img-path"])
+            == batch_dir.joinpath(str(df.iloc[-1]["uuid"]), f'{df.iloc[-1]["uuid"]}_cn.npy')
     )
 
     # test to check mcorr get_output_path()
     assert (
-        df.iloc[-1].mcorr.get_output_path()
-        == batch_dir.joinpath(
-            str(df.iloc[-1]["uuid"]),
-            f'{df.iloc[-1]["uuid"]}-mcorr_els__d1_60_d2_80_d3_1_order_F_frames_2000_.mmap',
-        )
-        == df.paths.resolve(df.iloc[-1]["outputs"]["mcorr-output-path"])
+            df.iloc[-1].mcorr.get_output_path()
+            == batch_dir.joinpath(
+        str(df.iloc[-1]["uuid"]),
+        f'{df.iloc[-1]["uuid"]}-mcorr_els__d1_60_d2_80_d3_1_order_F_frames_2000_.mmap',
+    )
+            == df.paths.resolve(df.iloc[-1]["outputs"]["mcorr-output-path"])
     )
 
     # test to check mcorr get_output()
@@ -374,12 +374,12 @@ def test_cnmf():
     assert df.iloc[-1]["outputs"]["traceback"] is None
 
     assert (
-        batch_dir.joinpath(df.iloc[-1]["outputs"]["mcorr-output-path"])
-        == df.paths.resolve(df.iloc[-1]["outputs"]["mcorr-output-path"])
-        == batch_dir.joinpath(
-            str(df.iloc[-1]["uuid"]),
-            f'{df.iloc[-1]["uuid"]}-mcorr_els__d1_60_d2_80_d3_1_order_F_frames_2000_.mmap',
-        )
+            batch_dir.joinpath(df.iloc[-1]["outputs"]["mcorr-output-path"])
+            == df.paths.resolve(df.iloc[-1]["outputs"]["mcorr-output-path"])
+            == batch_dir.joinpath(
+        str(df.iloc[-1]["uuid"]),
+        f'{df.iloc[-1]["uuid"]}-mcorr_els__d1_60_d2_80_d3_1_order_F_frames_2000_.mmap',
+    )
     )
 
     algo = "cnmf"
@@ -419,59 +419,59 @@ def test_cnmf():
     assert df.iloc[-1]["outputs"]["traceback"] is None
 
     assert (
-        input_movie_path
-        == df.iloc[-1].caiman.get_input_movie_path()
-        == df.paths.resolve(df.iloc[-1]["input_movie_path"])
+            input_movie_path
+            == df.iloc[-1].caiman.get_input_movie_path()
+            == df.paths.resolve(df.iloc[-1]["input_movie_path"])
     )
 
     assert (
-        batch_dir.joinpath(str(df.iloc[-1]["uuid"]), f'{df.iloc[-1]["uuid"]}.hdf5')
-        == df.paths.resolve(df.iloc[-1]["outputs"]["cnmf-hdf5-path"])
-        == batch_dir.joinpath(df.iloc[-1]["outputs"]["cnmf-hdf5-path"])
+            batch_dir.joinpath(str(df.iloc[-1]["uuid"]), f'{df.iloc[-1]["uuid"]}.hdf5')
+            == df.paths.resolve(df.iloc[-1]["outputs"]["cnmf-hdf5-path"])
+            == batch_dir.joinpath(df.iloc[-1]["outputs"]["cnmf-hdf5-path"])
     )
 
     # test to check mmap output path
     assert (
-        batch_dir.joinpath(
-            str(df.iloc[-1]["uuid"]),
-            f'{df.iloc[-1]["uuid"]}_cnmf-memmap__d1_60_d2_80_d3_1_order_C_frames_2000_.mmap',
-        )
-        == df.paths.resolve(df.iloc[-1]["outputs"]["cnmf-memmap-path"])
-        == batch_dir.joinpath(df.iloc[-1]["outputs"]["cnmf-memmap-path"])
+            batch_dir.joinpath(
+                str(df.iloc[-1]["uuid"]),
+                f'{df.iloc[-1]["uuid"]}_cnmf-memmap__d1_60_d2_80_d3_1_order_C_frames_2000_.mmap',
+            )
+            == df.paths.resolve(df.iloc[-1]["outputs"]["cnmf-memmap-path"])
+            == batch_dir.joinpath(df.iloc[-1]["outputs"]["cnmf-memmap-path"])
     )
 
     # test to check mean-projection output path
     assert (
-        batch_dir.joinpath(df.iloc[-1]["outputs"]["mean-projection-path"])
-        == df.paths.resolve(df.iloc[-1]["outputs"]["mean-projection-path"])
-        == batch_dir.joinpath(
-            str(df.iloc[-1]["uuid"]), f'{df.iloc[-1]["uuid"]}_mean_projection.npy'
-        )
+            batch_dir.joinpath(df.iloc[-1]["outputs"]["mean-projection-path"])
+            == df.paths.resolve(df.iloc[-1]["outputs"]["mean-projection-path"])
+            == batch_dir.joinpath(
+        str(df.iloc[-1]["uuid"]), f'{df.iloc[-1]["uuid"]}_mean_projection.npy'
+    )
     )
 
     # test to check std-projection output path
     assert (
-        batch_dir.joinpath(df.iloc[-1]["outputs"]["std-projection-path"])
-        == df.paths.resolve(df.iloc[-1]["outputs"]["std-projection-path"])
-        == batch_dir.joinpath(
-            str(df.iloc[-1]["uuid"]), f'{df.iloc[-1]["uuid"]}_std_projection.npy'
-        )
+            batch_dir.joinpath(df.iloc[-1]["outputs"]["std-projection-path"])
+            == df.paths.resolve(df.iloc[-1]["outputs"]["std-projection-path"])
+            == batch_dir.joinpath(
+        str(df.iloc[-1]["uuid"]), f'{df.iloc[-1]["uuid"]}_std_projection.npy'
+    )
     )
 
     # test to check max-projection output path
     assert (
-        batch_dir.joinpath(df.iloc[-1]["outputs"]["max-projection-path"])
-        == df.paths.resolve(df.iloc[-1]["outputs"]["max-projection-path"])
-        == batch_dir.joinpath(
-            str(df.iloc[-1]["uuid"]), f'{df.iloc[-1]["uuid"]}_max_projection.npy'
-        )
+            batch_dir.joinpath(df.iloc[-1]["outputs"]["max-projection-path"])
+            == df.paths.resolve(df.iloc[-1]["outputs"]["max-projection-path"])
+            == batch_dir.joinpath(
+        str(df.iloc[-1]["uuid"]), f'{df.iloc[-1]["uuid"]}_max_projection.npy'
+    )
     )
 
     # test to check correlation image output path
     assert (
-        batch_dir.joinpath(df.iloc[-1]["outputs"]["corr-img-path"])
-        == df.paths.resolve(df.iloc[-1]["outputs"]["corr-img-path"])
-        == batch_dir.joinpath(str(df.iloc[-1]["uuid"]), f'{df.iloc[-1]["uuid"]}_cn.npy')
+            batch_dir.joinpath(df.iloc[-1]["outputs"]["corr-img-path"])
+            == df.paths.resolve(df.iloc[-1]["outputs"]["corr-img-path"])
+            == batch_dir.joinpath(str(df.iloc[-1]["uuid"]), f'{df.iloc[-1]["uuid"]}_cn.npy')
     )
 
     print("testing cnmf.get_cnmf_memmap()")
@@ -495,10 +495,10 @@ def test_cnmf():
 
     # test to check cnmf get_output_path()
     assert (
-        df.iloc[-1].cnmf.get_output_path()
-        == batch_dir.joinpath(df.iloc[-1]["outputs"]["cnmf-hdf5-path"])
-        == df.paths.resolve(df.iloc[-1]["outputs"]["cnmf-hdf5-path"])
-        == batch_dir.joinpath(str(df.iloc[-1]["uuid"]), f'{df.iloc[-1]["uuid"]}.hdf5')
+            df.iloc[-1].cnmf.get_output_path()
+            == batch_dir.joinpath(df.iloc[-1]["outputs"]["cnmf-hdf5-path"])
+            == df.paths.resolve(df.iloc[-1]["outputs"]["cnmf-hdf5-path"])
+            == batch_dir.joinpath(str(df.iloc[-1]["uuid"]), f'{df.iloc[-1]["uuid"]}.hdf5')
     )
 
     # test to check cnmf get_output()
@@ -526,11 +526,11 @@ def test_cnmf():
         allow_pickle=True,
     )
     for contour, actual_contour in zip(
-        cnmf_spatial_contours_contours, cnmf_spatial_contours_contours_actual
+            cnmf_spatial_contours_contours, cnmf_spatial_contours_contours_actual
     ):
         numpy.testing.assert_allclose(contour, actual_contour, rtol=1e-2, atol=1e-10)
     for com, actual_com in zip(
-        cnmf_spatial_contours_coms, cnmf_spatial_contours_coms_actual
+            cnmf_spatial_contours_coms, cnmf_spatial_contours_coms_actual
     ):
         numpy.testing.assert_allclose(com, actual_com, rtol=1e-2, atol=1e-10)
 
@@ -554,9 +554,9 @@ def test_cnmf():
 
     # test to check caiman get_input_movie_path(), should be output of previous mcorr
     assert (
-        df.iloc[-1].caiman.get_input_movie_path()
-        == df.paths.resolve(df.iloc[-1]["input_movie_path"])
-        == batch_dir.joinpath(df.iloc[-1]["input_movie_path"])
+            df.iloc[-1].caiman.get_input_movie_path()
+            == df.paths.resolve(df.iloc[-1]["input_movie_path"])
+            == batch_dir.joinpath(df.iloc[-1]["input_movie_path"])
     )
 
     # test to check caiman get_correlation_img()
@@ -606,7 +606,7 @@ def test_cnmf():
         allow_pickle=True,
     )
     for contour, actual_contour in zip(
-        ixs_contours_contours, ixs_contours_contours_actual
+            ixs_contours_contours, ixs_contours_contours_actual
     ):
         numpy.testing.assert_allclose(contour, actual_contour, rtol=1e-2, atol=1e-10)
     for com, actual_com in zip(ixs_contours_coms, ixs_contours_coms_actual):
@@ -677,9 +677,9 @@ def test_cnmfe():
         pytest.fail("Something wrong with setting UUID for batch items")
 
     assert (
-        batch_dir.joinpath(df.iloc[-1]["input_movie_path"])
-        == batch_dir.joinpath(df.iloc[0].mcorr.get_output_path())
-        == df.paths.resolve(df.iloc[-1]["input_movie_path"])
+            batch_dir.joinpath(df.iloc[-1]["input_movie_path"])
+            == batch_dir.joinpath(df.iloc[0].mcorr.get_output_path())
+            == df.paths.resolve(df.iloc[-1]["input_movie_path"])
     )
 
     process = df.iloc[-1].caiman.run()
@@ -698,9 +698,9 @@ def test_cnmfe():
     assert df.iloc[-1]["outputs"]["traceback"] is None
 
     assert (
-        input_movie_path
-        == df.iloc[-1].caiman.get_input_movie_path()
-        == df.paths.resolve(df.iloc[-1]["input_movie_path"])
+            input_movie_path
+            == df.iloc[-1].caiman.get_input_movie_path()
+            == df.paths.resolve(df.iloc[-1]["input_movie_path"])
     )
 
     assert batch_dir.joinpath(
@@ -755,9 +755,9 @@ def test_cnmfe():
         pytest.fail("Something wrong with setting UUID for batch items")
 
     assert (
-        batch_dir.joinpath(df.iloc[-1]["input_movie_path"])
-        == batch_dir.joinpath(df.iloc[0].mcorr.get_output_path())
-        == df.paths.resolve(df.iloc[-1]["input_movie_path"])
+            batch_dir.joinpath(df.iloc[-1]["input_movie_path"])
+            == batch_dir.joinpath(df.iloc[0].mcorr.get_output_path())
+            == df.paths.resolve(df.iloc[-1]["input_movie_path"])
     )
 
     process = df.iloc[-1].caiman.run()
@@ -776,9 +776,9 @@ def test_cnmfe():
     assert df.iloc[-1]["outputs"]["traceback"] is None
 
     assert (
-        input_movie_path
-        == df.iloc[-1].caiman.get_input_movie_path()
-        == df.paths.resolve(df.iloc[-1]["input_movie_path"])
+            input_movie_path
+            == df.iloc[-1].caiman.get_input_movie_path()
+            == df.paths.resolve(df.iloc[-1]["input_movie_path"])
     )
 
     assert batch_dir.joinpath(
@@ -787,53 +787,53 @@ def test_cnmfe():
 
     # test to check mmap output path
     assert (
-        batch_dir.joinpath(
-            str(df.iloc[-1]["uuid"]),
-            f'{df.iloc[-1]["uuid"]}_cnmf-memmap__d1_128_d2_128_d3_1_order_C_frames_1000_.mmap',
-        )
-        == df.paths.resolve(df.iloc[-1]["outputs"]["cnmf-memmap-path"])
-        == batch_dir.joinpath(df.iloc[-1]["outputs"]["cnmf-memmap-path"])
+            batch_dir.joinpath(
+                str(df.iloc[-1]["uuid"]),
+                f'{df.iloc[-1]["uuid"]}_cnmf-memmap__d1_128_d2_128_d3_1_order_C_frames_1000_.mmap',
+            )
+            == df.paths.resolve(df.iloc[-1]["outputs"]["cnmf-memmap-path"])
+            == batch_dir.joinpath(df.iloc[-1]["outputs"]["cnmf-memmap-path"])
     )
 
     # test to check mean-projection output path
     assert (
-        batch_dir.joinpath(df.iloc[-1]["outputs"]["mean-projection-path"])
-        == df.paths.resolve(df.iloc[-1]["outputs"]["mean-projection-path"])
-        == batch_dir.joinpath(
-            str(df.iloc[-1]["uuid"]), f'{df.iloc[-1]["uuid"]}_mean_projection.npy'
-        )
+            batch_dir.joinpath(df.iloc[-1]["outputs"]["mean-projection-path"])
+            == df.paths.resolve(df.iloc[-1]["outputs"]["mean-projection-path"])
+            == batch_dir.joinpath(
+        str(df.iloc[-1]["uuid"]), f'{df.iloc[-1]["uuid"]}_mean_projection.npy'
+    )
     )
 
     # test to check std-projection output path
     assert (
-        batch_dir.joinpath(df.iloc[-1]["outputs"]["std-projection-path"])
-        == df.paths.resolve(df.iloc[-1]["outputs"]["std-projection-path"])
-        == batch_dir.joinpath(
-            str(df.iloc[-1]["uuid"]), f'{df.iloc[-1]["uuid"]}_std_projection.npy'
-        )
+            batch_dir.joinpath(df.iloc[-1]["outputs"]["std-projection-path"])
+            == df.paths.resolve(df.iloc[-1]["outputs"]["std-projection-path"])
+            == batch_dir.joinpath(
+        str(df.iloc[-1]["uuid"]), f'{df.iloc[-1]["uuid"]}_std_projection.npy'
+    )
     )
 
     # test to check max-projection output path
     assert (
-        batch_dir.joinpath(df.iloc[-1]["outputs"]["max-projection-path"])
-        == df.paths.resolve(df.iloc[-1]["outputs"]["max-projection-path"])
-        == batch_dir.joinpath(
-            str(df.iloc[-1]["uuid"]), f'{df.iloc[-1]["uuid"]}_max_projection.npy'
-        )
+            batch_dir.joinpath(df.iloc[-1]["outputs"]["max-projection-path"])
+            == df.paths.resolve(df.iloc[-1]["outputs"]["max-projection-path"])
+            == batch_dir.joinpath(
+        str(df.iloc[-1]["uuid"]), f'{df.iloc[-1]["uuid"]}_max_projection.npy'
+    )
     )
 
     # test to check correlation image output path
     assert (
-        batch_dir.joinpath(df.iloc[-1]["outputs"]["corr-img-path"])
-        == df.paths.resolve(df.iloc[-1]["outputs"]["corr-img-path"])
-        == batch_dir.joinpath(str(df.iloc[-1]["uuid"]), f'{df.iloc[-1]["uuid"]}_cn.npy')
+            batch_dir.joinpath(df.iloc[-1]["outputs"]["corr-img-path"])
+            == df.paths.resolve(df.iloc[-1]["outputs"]["corr-img-path"])
+            == batch_dir.joinpath(str(df.iloc[-1]["uuid"]), f'{df.iloc[-1]["uuid"]}_cn.npy')
     )
 
     # test to check pnr image output path
     assert (
-        batch_dir.joinpath(df.iloc[-1]["outputs"]["pnr-image-path"])
-        == df.paths.resolve(df.iloc[-1]["outputs"]["pnr-image-path"])
-        == batch_dir.joinpath(str(df.iloc[-1]["uuid"]), f'{df.iloc[-1]["uuid"]}_pn.npy')
+            batch_dir.joinpath(df.iloc[-1]["outputs"]["pnr-image-path"])
+            == df.paths.resolve(df.iloc[-1]["outputs"]["pnr-image-path"])
+            == batch_dir.joinpath(str(df.iloc[-1]["uuid"]), f'{df.iloc[-1]["uuid"]}_pn.npy')
     )
 
     # extension tests - full
@@ -857,9 +857,9 @@ def test_cnmfe():
 
     # test to check cnmf get_output_path()
     assert (
-        df.iloc[-1].cnmf.get_output_path()
-        == batch_dir.joinpath(df.iloc[-1]["outputs"]["cnmf-hdf5-path"])
-        == df.iloc[-1].paths.resolve(df.iloc[-1]["outputs"]["cnmf-hdf5-path"])
+            df.iloc[-1].cnmf.get_output_path()
+            == batch_dir.joinpath(df.iloc[-1]["outputs"]["cnmf-hdf5-path"])
+            == df.iloc[-1].paths.resolve(df.iloc[-1]["outputs"]["cnmf-hdf5-path"])
     )
 
     # test to check cnmf get_output()
@@ -887,11 +887,11 @@ def test_cnmfe():
         allow_pickle=True,
     )
     for contour, actual_contour in zip(
-        cnmfe_spatial_contours_contours, cnmfe_spatial_contours_contours_actual
+            cnmfe_spatial_contours_contours, cnmfe_spatial_contours_contours_actual
     ):
         numpy.testing.assert_allclose(contour, actual_contour, rtol=1e-2, atol=1e-10)
     for com, actual_com in zip(
-        cnmfe_spatial_contours_coms, cnmfe_spatial_contours_coms_actual
+            cnmfe_spatial_contours_coms, cnmfe_spatial_contours_coms_actual
     ):
         numpy.testing.assert_allclose(com, actual_com, rtol=1e-2, atol=1e-10)
 
@@ -946,7 +946,7 @@ def test_cnmfe():
         allow_pickle=True,
     )
     for contour, actual_contour in zip(
-        ixs_contours_contours, ixs_contours_contours_actual
+            ixs_contours_contours, ixs_contours_contours_actual
     ):
         numpy.testing.assert_allclose(contour, actual_contour, rtol=1e-2, atol=1e-10)
     for com, actual_com in zip(ixs_contours_coms, ixs_contours_coms_actual):
@@ -1000,9 +1000,9 @@ def test_remove_item():
         pytest.fail("Something wrong with setting UUID for batch items")
 
     assert (
-        get_full_raw_data_path(df.iloc[-1]["input_movie_path"])
-        == vid_dir.joinpath(f"{algo}.tif")
-        == vid_dir.joinpath(df.iloc[-1]["input_movie_path"])
+            get_full_raw_data_path(df.iloc[-1]["input_movie_path"])
+            == vid_dir.joinpath(f"{algo}.tif")
+            == vid_dir.joinpath(df.iloc[-1]["input_movie_path"])
     )
 
     df.caiman.add_item(
@@ -1022,9 +1022,9 @@ def test_remove_item():
         pytest.fail("Something wrong with setting UUID for batch items")
 
     assert (
-        get_full_raw_data_path(df.iloc[-1]["input_movie_path"])
-        == vid_dir.joinpath(f"{algo}.tif")
-        == vid_dir.joinpath(df.iloc[-1]["input_movie_path"])
+            get_full_raw_data_path(df.iloc[-1]["input_movie_path"])
+            == vid_dir.joinpath(f"{algo}.tif")
+            == vid_dir.joinpath(df.iloc[-1]["input_movie_path"])
     )
     # Check removing specific rows works
     assert df.iloc[0]["name"] == f"test-{algo}"
@@ -1038,6 +1038,7 @@ def test_remove_item():
     assert df.isin([f"test-{algo}"]).any().any() == False
     assert df.isin([f"test1-{algo}"]).any().any() == False
     assert df.empty == True
+
 
 def test_cache():
     set_parent_raw_data_path(vid_dir)
@@ -1133,8 +1134,8 @@ def test_cache():
     hex_get_output = hex(id(cnmf_output))
     cache = cnmf.cache.get_cache()
     hex1 = hex(id(cache[cache["function"] == "get_output"]["return_val"].item()))
-    #assert(hex(id(df.iloc[-1].cnmf.get_output(copy=False))) == hex1)
-    #assert(hex_get_output != hex1)
+    # assert(hex(id(df.iloc[-1].cnmf.get_output(copy=False))) == hex1)
+    # assert(hex_get_output != hex1)
     time_stamp1 = cache[cache["function"] == "get_output"]["time_stamp"].item()
     df.iloc[-1].cnmf.get_temporal_components()
     df.iloc[-1].cnmf.get_spatial_contours()
@@ -1155,12 +1156,36 @@ def test_cache():
     df.iloc[-1].cnmf.get_spatial_masks(np.arange(3))
     time_stamp2 = cache[cache["function"] == "get_output"]["time_stamp"].item()
     hex2 = hex(id(cache[cache["function"] == "get_output"]["return_val"].item()))
-    assert(cache[cache["function"] == "get_output"].index.size == 1)
-    assert(len(cnmf.cache.get_cache().index) == 17)
-    assert(time_stamp2 > time_stamp1)
-    assert(hex1 == hex2)
+    assert (cache[cache["function"] == "get_output"].index.size == 1)
+    assert (len(cnmf.cache.get_cache().index) == 17)
+    assert (time_stamp2 > time_stamp1)
+    assert (hex1 == hex2)
 
+    # test clear_cache()
+    cnmf.cache.clear_cache()
+    assert (len(cnmf.cache.get_cache().index) == 0)
 
+    import time
+
+    start = time.time()
+    df.iloc[-1].cnmf.get_output()
+    end = time.time()
+    assert (len(cnmf.cache.get_cache().index) == 1)
+
+    start2 = time.time()
+    df.iloc[-1].cnmf.get_output()
+    end2 = time.time()
+
+    assert(end2-start2 < end-start)
+
+    # test setting maxsize as 0
+    cnmf.cache.clear_cache()
+    assert (len(cnmf.cache.get_cache().index) == 0)
+
+    cnmf.cache.set_maxsize(0)
+    df.iloc[-1].cnmf.get_output()
+    print(cnmf.cache.get_cache())
+    # assert (len(cnmf.cache.get_cache().index) == 0)
 
 
 


### PR DESCRIPTION
adding file to extensions for a cache

cache should allow users to quickly access results of previously made calls to cnmf extensions that have the same ```function_name, args,``` and ```kwargs```