### PR TITLE
windows compatibility

### DIFF
--- a/.github/workflows/conda-windows.yaml
+++ b/.github/workflows/conda-windows.yaml
@@ -1,69 +1,84 @@
 name: Windows Conda
 
-on: [push]
-
-jobs:
-  test:
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install Conda environment from environment.yml
-        uses: mamba-org/provision-with-micromamba@main
-        with:
-          environment-file: environment.yml
-          environment-name: mescore
-          extra-specs: |
-            python=3.8
-
-      - name: install mesmerize
-        shell: bash -l {0}
-        run: |
-          micromamba activate mescore
-          caimanmanager.py install
-          micromamba install pytest
-          # pip install git+https://github.com/pandas-dev/pandas.git
-          pip install "https://pypi.anaconda.org/scipy-wheels-nightly/simple/pandas/1.5.0.dev0%2B1172.ga7c5773d19/pandas-1.5.0.dev0%2B1172.ga7c5773d19-cp38-cp38-win_amd64.whl"
-          pip install .
-          
-      - name: pytests
-        shell: bash -l {0}
-        run: |
-          micromamba activate mescore
-          export DOWNLOAD_GROUND_TRUTHS=1 pytest -s .
+# on: [push]
 
 # jobs:
-#   build-windows:
+#   test:
 #     runs-on: windows-latest
-#     strategy:
-#       max-parallel: 5
-      
 #     steps:
-#     - uses: conda-incubator/setup-miniconda@v2
-#       with:
-#         miniconda-version: "latest"
-#         activate-environment: foo
+#       - uses: actions/checkout@v2
+#       - name: Install Conda environment from environment.yml
+#         uses: mamba-org/provision-with-micromamba@main
+#         with:
+#           environment-file: environment.yml
+#           environment-name: mescore
+#           extra-specs: |
+#             python=3.9
+
+#       - name: install mesmerize
+#         shell: bash -l {0}
+#         run: |
+#           micromamba activate mescore
+#           caimanmanager.py install
+#           micromamba install pytest
+#           # pip install git+https://github.com/pandas-dev/pandas.git
+#           pip install "https://pypi.anaconda.org/scipy-wheels-nightly/simple/pandas/1.5.0.dev0%2B1172.ga7c5773d19/pandas-1.5.0.dev0%2B1172.ga7c5773d19-cp38-cp38-win_amd64.whl"
+#           pip install .
           
-#     - name: install mamba
-#       shell: bash -l {0}
-#       run: |
-#         conda info
-#         conda install -c conda-forge mamba
-#         conda clean -a
+#       - name: pytests
+#         shell: bash -l {0}
+#         run: |
+#           micromamba activate mescore
+#           export DOWNLOAD_GROUND_TRUTHS=1 pytest -s .
 
-#     - name: install mesmerize-core
-#       shell: bash -l {0}
-#       run: |
-#         mamba env update --file environment.yml
-#         #mamba create -n mescore --file environment.yml
-#         # mamba env update -n foo --file environment.yml
-#         caimanmanager.py install
-#         pip install "https://pypi.anaconda.org/scipy-wheels-nightly/simple/pandas/1.5.0.dev0%2B1172.ga7c5773d19/pandas-1.5.0.dev0%2B1172.ga7c5773d19-cp39-cp39-win_amd64.whl"
-#         pip install .
+# name: Python Package using Conda
 
-#     - name: Test with pytest
-#       shell: bash -l {0}
-#       run: |
-#         conda activate mescore
-#         mamba install pytest
-#         #$env:DOWNLOAD_GROUND_TRUTHS="1"
-#         export DOWNLOAD_GROUND_TRUTHS=1 pytest -s .
+on:
+  pull_request:
+    branches:
+      - master
+      - dev
+  push:
+    branches: [ master ]
+
+jobs:
+  build-linux:
+    runs-on: windows-latest
+    strategy:
+      max-parallel: 5
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python '3.10'
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.10'
+    - name: Add conda to system path
+      shell: bash -l {0}
+      run: |
+        # $CONDA is an environment variable pointing to the root of the miniconda directory
+        echo $CONDA/bin >> $GITHUB_PATH
+        
+    - name: Install mamba
+      shell: bash -l {0}
+      run: |
+        conda install -c conda-forge mamba
+        conda clean -a
+        
+        #   - name: install caiman
+        #     run: |
+        #       mamba install -c conda-forge caiman
+        
+    - name: install mesmerize-core
+      shell: bash -l {0}
+      run: |
+        mamba env update -n base --file environment.yml
+        caimanmanager.py install
+        pip install git+https://github.com/pandas-dev/pandas.git
+        pip install .
+        
+    - name: Test with pytest
+      shell: bash -l {0}
+      run: |
+        mamba install pytest
+        DOWNLOAD_GROUND_TRUTHS=1 pytest -s .

--- a/.github/workflows/conda-windows.yaml
+++ b/.github/workflows/conda-windows.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Run Python
         shell: bash -l {0}
         run: |
-          conda activate mescore
+          micromamba activate mescore
           caimanmanager.py install
 
 # jobs:

--- a/.github/workflows/conda-windows.yaml
+++ b/.github/workflows/conda-windows.yaml
@@ -3,38 +3,51 @@ name: Windows Conda
 on: [push]
 
 jobs:
-  build-windows:
+  test:
     runs-on: windows-latest
-    strategy:
-      max-parallel: 5
-      
     steps:
-    - uses: conda-incubator/setup-miniconda@v2
-      with:
-        miniconda-version: "latest"
-        activate-environment: foo
+      - uses: actions/checkout@v2
+      - name: Install Conda environment from environment.yml
+        uses: mamba-org/provision-with-micromamba@main
+        
+      - name: Run Python
+        shell: bash -l {0}
+        run: |
+          caimanmanager.py install
+
+# jobs:
+#   build-windows:
+#     runs-on: windows-latest
+#     strategy:
+#       max-parallel: 5
+      
+#     steps:
+#     - uses: conda-incubator/setup-miniconda@v2
+#       with:
+#         miniconda-version: "latest"
+#         activate-environment: foo
           
-    - name: install mamba
-      shell: bash -l {0}
-      run: |
-        conda info
-        conda install -c conda-forge mamba
-        conda clean -a
+#     - name: install mamba
+#       shell: bash -l {0}
+#       run: |
+#         conda info
+#         conda install -c conda-forge mamba
+#         conda clean -a
 
-    - name: install mesmerize-core
-      shell: bash -l {0}
-      run: |
-        mamba env update --file environment.yml
-        #mamba create -n mescore --file environment.yml
-        # mamba env update -n foo --file environment.yml
-        caimanmanager.py install
-        pip install "https://pypi.anaconda.org/scipy-wheels-nightly/simple/pandas/1.5.0.dev0%2B1172.ga7c5773d19/pandas-1.5.0.dev0%2B1172.ga7c5773d19-cp39-cp39-win_amd64.whl"
-        pip install .
+#     - name: install mesmerize-core
+#       shell: bash -l {0}
+#       run: |
+#         mamba env update --file environment.yml
+#         #mamba create -n mescore --file environment.yml
+#         # mamba env update -n foo --file environment.yml
+#         caimanmanager.py install
+#         pip install "https://pypi.anaconda.org/scipy-wheels-nightly/simple/pandas/1.5.0.dev0%2B1172.ga7c5773d19/pandas-1.5.0.dev0%2B1172.ga7c5773d19-cp39-cp39-win_amd64.whl"
+#         pip install .
 
-    - name: Test with pytest
-      shell: bash -l {0}
-      run: |
-        conda activate mescore
-        mamba install pytest
-        #$env:DOWNLOAD_GROUND_TRUTHS="1"
-        export DOWNLOAD_GROUND_TRUTHS=1 pytest -s .
+#     - name: Test with pytest
+#       shell: bash -l {0}
+#       run: |
+#         conda activate mescore
+#         mamba install pytest
+#         #$env:DOWNLOAD_GROUND_TRUTHS="1"
+#         export DOWNLOAD_GROUND_TRUTHS=1 pytest -s .

--- a/.github/workflows/conda-windows.yaml
+++ b/.github/workflows/conda-windows.yaml
@@ -37,8 +37,7 @@ jobs:
           caimanmanager.py install
           pip install https://pypi.anaconda.org/scipy-wheels-nightly/simple/pandas/1.5.0.dev0%2B1172.ga7c5773d19/pandas-1.5.0.dev0%2B1172.ga7c5773d19-cp39-cp39-win_amd64.whl
           pip install .
-          conda activate mescore
-          export DOWNLOAD_GROUND_TRUTHS=1 pytest -s .
+          DOWNLOAD_GROUND_TRUTHS=1 pytest -s .
 
 # on: [push]
 

--- a/.github/workflows/conda-windows.yaml
+++ b/.github/workflows/conda-windows.yaml
@@ -3,37 +3,46 @@ name: Windows Conda
 on: [push]
 
 jobs:
-  build-windows:
+  build:
     runs-on: windows-latest
-    strategy:
-      max-parallel: 5
-      
     steps:
     - uses: conda-incubator/setup-miniconda@v2
-      with:
-        miniconda-version: "latest"
-        activate-environment: foo
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v3
+
+
+# jobs:
+#   build-windows:
+#     runs-on: windows-latest
+#     strategy:
+#       max-parallel: 5
+      
+#     steps:
+#     - uses: conda-incubator/setup-miniconda@v2
+#       with:
+#         miniconda-version: "latest"
+#         activate-environment: foo
           
-    - name: install mamba
-      shell: bash -l {0}
-      run: |
-        conda info
-        conda install -c conda-forge mamba
-        conda clean -a
+#     - name: install mamba
+#       shell: bash -l {0}
+#       run: |
+#         conda info
+#         conda install -c conda-forge mamba
+#         conda clean -a
 
-    - name: install mesmerize-core
-      shell: bash -l {0}
-      run: |
-        mamba create -n mescore --file environment.yml
-        # mamba env update -n foo --file environment.yml
-        caimanmanager.py install
-        pip install "https://pypi.anaconda.org/scipy-wheels-nightly/simple/pandas/1.5.0.dev0%2B1172.ga7c5773d19/pandas-1.5.0.dev0%2B1172.ga7c5773d19-cp39-cp39-win_amd64.whl"
-        pip install .
+#     - name: install mesmerize-core
+#       shell: bash -l {0}
+#       run: |
+#         mamba create -n mescore --file environment.yml
+#         # mamba env update -n foo --file environment.yml
+#         caimanmanager.py install
+#         pip install "https://pypi.anaconda.org/scipy-wheels-nightly/simple/pandas/1.5.0.dev0%2B1172.ga7c5773d19/pandas-1.5.0.dev0%2B1172.ga7c5773d19-cp39-cp39-win_amd64.whl"
+#         pip install .
 
-    - name: Test with pytest
-      shell: bash -l {0}
-      run: |
-        conda activate mescore
-        mamba install pytest
-        #$env:DOWNLOAD_GROUND_TRUTHS="1"
-        export DOWNLOAD_GROUND_TRUTHS=1 pytest -s .
+#     - name: Test with pytest
+#       shell: bash -l {0}
+#       run: |
+#         conda activate mescore
+#         mamba install pytest
+#         #$env:DOWNLOAD_GROUND_TRUTHS="1"
+#         export DOWNLOAD_GROUND_TRUTHS=1 pytest -s .

--- a/.github/workflows/conda-windows.yaml
+++ b/.github/workflows/conda-windows.yaml
@@ -13,6 +13,7 @@ jobs:
     name: Ex6 Mamba
     runs-on: "windows-latest"
     steps:
+      - name: setup mamba environment
       - uses: actions/checkout@v2
       - uses: conda-incubator/setup-miniconda@v2
         with:
@@ -29,13 +30,20 @@ jobs:
           conda config --show-sources
           conda config --show
           printenv | sort
+          
+      - name: install mesmerize-core
       - shell: bash -l {0}
         run: |
           conda activate mescore
           mamba install pytest
           caimanmanager.py install
-          
-
+          pip install https://pypi.anaconda.org/scipy-wheels-nightly/simple/pandas/1.5.0.dev0%2B1172.ga7c5773d19/pandas-1.5.0.dev0%2B1172.ga7c5773d19-cp39-cp39-win_amd64.whl
+          pip install .
+      - name: pytests
+      - shell: bash -l {0}
+        run: |
+          conda activate mescore
+          export DOWNLOAD_GROUND_TRUTHS=1 pytest -s .
 
 # on: [push]
 
@@ -59,7 +67,7 @@ jobs:
 #           caimanmanager.py install
 #           micromamba install pytest
 #           # pip install git+https://github.com/pandas-dev/pandas.git
-#           pip install "https://pypi.anaconda.org/scipy-wheels-nightly/simple/pandas/1.5.0.dev0%2B1172.ga7c5773d19/pandas-1.5.0.dev0%2B1172.ga7c5773d19-cp38-cp38-win_amd64.whl"
+#           pip install "https://pypi.anaconda.org/scipy-wheels-nightly/simple/pandas/1.5.0.dev0%2B1172.ga7c5773d19/pandas-1.5.0.dev0%2B1172.ga7c5773d19-cp39-cp39-win_amd64.whl"
 #           pip install .
           
 #       - name: pytests

--- a/.github/workflows/conda-windows.yaml
+++ b/.github/workflows/conda-windows.yaml
@@ -24,7 +24,8 @@ jobs:
     - name: install mesmerize-core
       shell: bash -l {0}
       run: |
-        mamba env update -n foo --file environment.yml
+        # mamba env update -n foo --file environment.yml
+        mamba env create -n mescore --file my_env.yml
         caimanmanager.py install
         pip install "https://pypi.anaconda.org/scipy-wheels-nightly/simple/pandas/1.5.0.dev0%2B1172.ga7c5773d19/pandas-1.5.0.dev0%2B1172.ga7c5773d19-cp39-cp39-win_amd64.whl"
         pip install .
@@ -32,6 +33,7 @@ jobs:
     - name: Test with pytest
       shell: bash -l {0}
       run: |
+        conda activate mescore
         mamba install pytest
         #$env:DOWNLOAD_GROUND_TRUTHS="1"
         export DOWNLOAD_GROUND_TRUTHS=1 pytest -s .

--- a/.github/workflows/conda-windows.yaml
+++ b/.github/workflows/conda-windows.yaml
@@ -29,9 +29,11 @@ jobs:
         conda info
         conda install -c conda-forge mamba
         conda clean -a
+        
+    - name: setup tmate session
+      uses: mxschmitt/action-tmate@v3
 
     - name: install mesmerize-core
-      uses: mxschmitt/action-tmate@v3
       shell: bash -l {0}
       run: |
         #mamba create -n mescore --file environment.yml

--- a/.github/workflows/conda-windows.yaml
+++ b/.github/workflows/conda-windows.yaml
@@ -9,6 +9,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install Conda environment from environment.yml
         uses: mamba-org/provision-with-micromamba@main
+          with:
+            environment-name: mescore
         
       - name: Run Python
         shell: bash -l {0}

--- a/.github/workflows/conda-windows.yaml
+++ b/.github/workflows/conda-windows.yaml
@@ -13,7 +13,6 @@ jobs:
     name: Ex6 Mamba
     runs-on: "windows-latest"
     steps:
-      - name: setup mamba environment
       - uses: actions/checkout@v2
       - uses: conda-incubator/setup-miniconda@v2
         with:
@@ -39,6 +38,7 @@ jobs:
           caimanmanager.py install
           pip install https://pypi.anaconda.org/scipy-wheels-nightly/simple/pandas/1.5.0.dev0%2B1172.ga7c5773d19/pandas-1.5.0.dev0%2B1172.ga7c5773d19-cp39-cp39-win_amd64.whl
           pip install .
+          
       - name: pytests
       - shell: bash -l {0}
         run: |

--- a/.github/workflows/conda-windows.yaml
+++ b/.github/workflows/conda-windows.yaml
@@ -24,7 +24,7 @@ jobs:
     - name: install mesmerize-core
       shell: bash -l {0}
       run: |
-        mamba env create -n mescore --file environment.yml
+        mamba create -n mescore --file environment.yml
         # mamba env update -n foo --file environment.yml
         caimanmanager.py install
         pip install "https://pypi.anaconda.org/scipy-wheels-nightly/simple/pandas/1.5.0.dev0%2B1172.ga7c5773d19/pandas-1.5.0.dev0%2B1172.ga7c5773d19-cp39-cp39-win_amd64.whl"

--- a/.github/workflows/conda-windows.yaml
+++ b/.github/workflows/conda-windows.yaml
@@ -30,7 +30,6 @@ jobs:
           conda config --show
           printenv | sort
           
-      - name: install mesmerize-core
       - shell: bash -l {0}
         run: |
           conda activate mescore
@@ -38,10 +37,6 @@ jobs:
           caimanmanager.py install
           pip install https://pypi.anaconda.org/scipy-wheels-nightly/simple/pandas/1.5.0.dev0%2B1172.ga7c5773d19/pandas-1.5.0.dev0%2B1172.ga7c5773d19-cp39-cp39-win_amd64.whl
           pip install .
-          
-      - name: pytests
-      - shell: bash -l {0}
-        run: |
           conda activate mescore
           export DOWNLOAD_GROUND_TRUTHS=1 pytest -s .
 

--- a/.github/workflows/conda-windows.yaml
+++ b/.github/workflows/conda-windows.yaml
@@ -24,8 +24,8 @@ jobs:
     - name: install mesmerize-core
       shell: bash -l {0}
       run: |
+        mamba env create -n mescore --file environment.yml
         # mamba env update -n foo --file environment.yml
-        mamba env create -n mescore --file my_env.yml
         caimanmanager.py install
         pip install "https://pypi.anaconda.org/scipy-wheels-nightly/simple/pandas/1.5.0.dev0%2B1172.ga7c5773d19/pandas-1.5.0.dev0%2B1172.ga7c5773d19-cp39-cp39-win_amd64.whl"
         pip install .

--- a/.github/workflows/conda-windows.yaml
+++ b/.github/workflows/conda-windows.yaml
@@ -12,8 +12,9 @@ jobs:
         with:
           environment-file: environment.yml
           environment-name: mescore
+          extra-specs: |
+            python=3.9
 
-        
       - name: install mesmerize
         shell: bash -l {0}
         run: |
@@ -22,6 +23,7 @@ jobs:
           micromamba install pytest
           pip install "https://pypi.anaconda.org/scipy-wheels-nightly/simple/pandas/1.5.0.dev0%2B1172.ga7c5773d19/pandas-1.5.0.dev0%2B1172.ga7c5773d19-cp39-cp39-win_amd64.whl"
           pip install .
+          
       - name: pytests
         shell: bash -l {0}
         run: |

--- a/.github/workflows/conda-windows.yaml
+++ b/.github/workflows/conda-windows.yaml
@@ -12,8 +12,8 @@ jobs:
         with:
           environment-file: environment.yml
           environment-name: mescore
-          extra-specs: |
-            python=3.10
+#           extra-specs: |
+#             python=3.10
 
       - name: install mesmerize
         shell: bash -l {0}
@@ -21,7 +21,8 @@ jobs:
           micromamba activate mescore
           caimanmanager.py install
           micromamba install pytest
-          pip install "https://pypi.anaconda.org/scipy-wheels-nightly/simple/pandas/1.5.0.dev0%2B1188.g8c7b0b2684/pandas-1.5.0.dev0%2B1188.g8c7b0b2684-cp310-cp310-win_amd64.whl"
+          pip install git+https://github.com/pandas-dev/pandas.git
+          # pip install "https://pypi.anaconda.org/scipy-wheels-nightly/simple/pandas/1.5.0.dev0%2B1188.g8c7b0b2684/pandas-1.5.0.dev0%2B1188.g8c7b0b2684-cp310-cp310-win_amd64.whl"
           pip install .
           
       - name: pytests

--- a/.github/workflows/conda-windows.yaml
+++ b/.github/workflows/conda-windows.yaml
@@ -32,11 +32,12 @@ jobs:
       run: |
         mamba env update -n base --file environment.yml
         caimanmanager.py install
-        pip install git+https://github.com/pandas-dev/pandas.git
+        pip install "https://pypi.anaconda.org/scipy-wheels-nightly/simple/pandas/1.5.0.dev0%2B1172.ga7c5773d19/pandas-1.5.0.dev0%2B1172.ga7c5773d19-cp39-cp39-win_amd64.whl"
         pip install .
         
     - name: Test with pytest
       run: |
         mamba install pytest
-        $env:DOWNLOAD_GROUND_TRUTHS="1" pytest -s .
+        $env:DOWNLOAD_GROUND_TRUTHS="1"
+        pytest -s .
         

--- a/.github/workflows/conda-windows.yaml
+++ b/.github/workflows/conda-windows.yaml
@@ -1,5 +1,38 @@
 name: Windows Conda
 
+on:
+  pull_request:
+    branches:
+      - master
+      - dev
+  push:
+    branches: [ master ]
+
+jobs:
+  example-6:
+    name: Ex6 Mamba
+    runs-on: "windows-latest"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          python-version: 3.10
+          mamba-version: "*"
+          channels: conda-forge,defaults
+          channel-priority: true
+          activate-environment: anaconda-client-env
+          environment-file: environment.yml
+      - shell: bash -l {0}
+        run: |
+          conda info
+          conda list
+          conda config --show-sources
+          conda config --show
+          printenv | sort
+      - shell: bash -l {0}
+        run: mamba install jupyterlab
+
+
 # on: [push]
 
 # jobs:
@@ -33,52 +66,52 @@ name: Windows Conda
 
 # name: Python Package using Conda
 
-on:
-  pull_request:
-    branches:
-      - master
-      - dev
-  push:
-    branches: [ master ]
+# on:
+#   pull_request:
+#     branches:
+#       - master
+#       - dev
+#   push:
+#     branches: [ master ]
 
-jobs:
-  build-linux:
-    runs-on: windows-latest
-    strategy:
-      max-parallel: 5
+# jobs:
+#   build-linux:
+#     runs-on: windows-latest
+#     strategy:
+#       max-parallel: 5
 
-    steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python '3.10'
-      uses: actions/setup-python@v3
-      with:
-        python-version: '3.10'
-    - name: Add conda to system path
-      shell: bash -l {0}
-      run: |
-        # $CONDA is an environment variable pointing to the root of the miniconda directory
-        echo $CONDA/bin >> $GITHUB_PATH
+#     steps:
+#     - uses: actions/checkout@v3
+#     - name: Set up Python '3.10'
+#       uses: actions/setup-python@v3
+#       with:
+#         python-version: '3.10'
+#     - name: Add conda to system path
+#       shell: bash -l {0}
+#       run: |
+#         # $CONDA is an environment variable pointing to the root of the miniconda directory
+#         echo $CONDA/bin >> $GITHUB_PATH
         
-    - name: Install mamba
-      shell: bash -l {0}
-      run: |
-        conda install -c conda-forge mamba
-        conda clean -a
+#     - name: Install mamba
+#       shell: bash -l {0}
+#       run: |
+#         conda install -c conda-forge mamba
+#         conda clean -a
         
-        #   - name: install caiman
-        #     run: |
-        #       mamba install -c conda-forge caiman
+#         #   - name: install caiman
+#         #     run: |
+#         #       mamba install -c conda-forge caiman
         
-    - name: install mesmerize-core
-      shell: bash -l {0}
-      run: |
-        mamba env update -n base --file environment.yml
-        caimanmanager.py install
-        pip install git+https://github.com/pandas-dev/pandas.git
-        pip install .
+#     - name: install mesmerize-core
+#       shell: bash -l {0}
+#       run: |
+#         mamba env update -n base --file environment.yml
+#         caimanmanager.py install
+#         pip install git+https://github.com/pandas-dev/pandas.git
+#         pip install .
         
-    - name: Test with pytest
-      shell: bash -l {0}
-      run: |
-        mamba install pytest
-        DOWNLOAD_GROUND_TRUTHS=1 pytest -s .
+#     - name: Test with pytest
+#       shell: bash -l {0}
+#       run: |
+#         mamba install pytest
+#         DOWNLOAD_GROUND_TRUTHS=1 pytest -s .

--- a/.github/workflows/conda-windows.yaml
+++ b/.github/workflows/conda-windows.yaml
@@ -12,8 +12,8 @@ jobs:
         with:
           environment-file: environment.yml
           environment-name: mescore
-#           extra-specs: |
-#             python=3.10
+           extra-specs: |
+             python=3.8
 
       - name: install mesmerize
         shell: bash -l {0}
@@ -21,8 +21,8 @@ jobs:
           micromamba activate mescore
           caimanmanager.py install
           micromamba install pytest
-          pip install git+https://github.com/pandas-dev/pandas.git
-          # pip install "https://pypi.anaconda.org/scipy-wheels-nightly/simple/pandas/1.5.0.dev0%2B1188.g8c7b0b2684/pandas-1.5.0.dev0%2B1188.g8c7b0b2684-cp310-cp310-win_amd64.whl"
+          # pip install git+https://github.com/pandas-dev/pandas.git
+          pip install "https://pypi.anaconda.org/scipy-wheels-nightly/simple/pandas/1.5.0.dev0%2B1172.ga7c5773d19/pandas-1.5.0.dev0%2B1172.ga7c5773d19-cp38-cp38-win_amd64.whl"
           pip install .
           
       - name: pytests

--- a/.github/workflows/conda-windows.yaml
+++ b/.github/workflows/conda-windows.yaml
@@ -23,6 +23,7 @@ jobs:
     - name: Install mamba
       shell: bash -l {0}
       run: |
+        source ~/.bash_profile
         conda install -c conda-forge mamba
         conda clean -a
         

--- a/.github/workflows/conda-windows.yaml
+++ b/.github/workflows/conda-windows.yaml
@@ -2,47 +2,48 @@ name: Windows Conda
 
 on: [push]
 
-jobs:
-  build:
-    runs-on: windows-latest
-    steps:
-    - uses: conda-incubator/setup-miniconda@v2
-    - name: Setup tmate session
-      uses: mxschmitt/action-tmate@v3
-
-
 # jobs:
-#   build-windows:
+#   build:
 #     runs-on: windows-latest
-#     strategy:
-#       max-parallel: 5
-      
 #     steps:
 #     - uses: conda-incubator/setup-miniconda@v2
-#       with:
-#         miniconda-version: "latest"
-#         activate-environment: foo
+#     - name: Setup tmate session
+#       uses: mxschmitt/action-tmate@v3
+
+
+jobs:
+  build-windows:
+    runs-on: windows-latest
+    strategy:
+      max-parallel: 5
+      
+    steps:
+    - uses: conda-incubator/setup-miniconda@v2
+      with:
+        miniconda-version: "latest"
+        activate-environment: foo
           
-#     - name: install mamba
-#       shell: bash -l {0}
-#       run: |
-#         conda info
-#         conda install -c conda-forge mamba
-#         conda clean -a
+    - name: install mamba
+      shell: bash -l {0}
+      run: |
+        conda info
+        conda install -c conda-forge mamba
+        conda clean -a
 
-#     - name: install mesmerize-core
-#       shell: bash -l {0}
-#       run: |
-#         mamba create -n mescore --file environment.yml
-#         # mamba env update -n foo --file environment.yml
-#         caimanmanager.py install
-#         pip install "https://pypi.anaconda.org/scipy-wheels-nightly/simple/pandas/1.5.0.dev0%2B1172.ga7c5773d19/pandas-1.5.0.dev0%2B1172.ga7c5773d19-cp39-cp39-win_amd64.whl"
-#         pip install .
+    - name: install mesmerize-core
+      uses: mxschmitt/action-tmate@v3
+      shell: bash -l {0}
+      run: |
+        #mamba create -n mescore --file environment.yml
+        # mamba env update -n foo --file environment.yml
+        caimanmanager.py install
+        #pip install "https://pypi.anaconda.org/scipy-wheels-nightly/simple/pandas/1.5.0.dev0%2B1172.ga7c5773d19/pandas-1.5.0.dev0%2B1172.ga7c5773d19-cp39-cp39-win_amd64.whl"
+        #pip install .
 
-#     - name: Test with pytest
-#       shell: bash -l {0}
-#       run: |
-#         conda activate mescore
-#         mamba install pytest
-#         #$env:DOWNLOAD_GROUND_TRUTHS="1"
-#         export DOWNLOAD_GROUND_TRUTHS=1 pytest -s .
+    - name: Test with pytest
+      shell: bash -l {0}
+      run: |
+        conda activate mescore
+        mamba install pytest
+        #$env:DOWNLOAD_GROUND_TRUTHS="1"
+        export DOWNLOAD_GROUND_TRUTHS=1 pytest -s .

--- a/.github/workflows/conda-windows.yaml
+++ b/.github/workflows/conda-windows.yaml
@@ -3,34 +3,24 @@ name: Windows Conda
 on: [push]
 
 jobs:
-  build-linux:
+  build-windows:
     runs-on: windows-latest
     strategy:
       max-parallel: 5
-
+      
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v3
+    - uses: conda-incubator/setup-miniconda@v2
       with:
-        python-version: 3.9
-    - name: Add conda to system path
+        miniconda-version: "latest"
+        activate-environment: foo
+          
+    - name: install mamba
       shell: bash -l {0}
       run: |
-        # $CONDA is an environment variable pointing to the root of the miniconda directory
-        echo $CONDA/bin >> $GITHUB_PATH
-        
-    - name: Install mamba
-      shell: bash -l {0}
-      run: |
-        source ~/.bash_profile
+        conda info
         conda install -c conda-forge mamba
         conda clean -a
-        
-        #   - name: install caiman
-        #     run: |
-        #       mamba install -c conda-forge caiman
-        
+
     - name: install mesmerize-core
       shell: bash -l {0}
       run: |
@@ -38,11 +28,10 @@ jobs:
         caimanmanager.py install
         pip install "https://pypi.anaconda.org/scipy-wheels-nightly/simple/pandas/1.5.0.dev0%2B1172.ga7c5773d19/pandas-1.5.0.dev0%2B1172.ga7c5773d19-cp39-cp39-win_amd64.whl"
         pip install .
-        
+
     - name: Test with pytest
       shell: bash -l {0}
       run: |
         mamba install pytest
         #$env:DOWNLOAD_GROUND_TRUTHS="1"
         export DOWNLOAD_GROUND_TRUTHS=1 pytest -s .
-        

--- a/.github/workflows/conda-windows.yaml
+++ b/.github/workflows/conda-windows.yaml
@@ -16,11 +16,11 @@ jobs:
       - uses: actions/checkout@v2
       - uses: conda-incubator/setup-miniconda@v2
         with:
-          python-version: 3.10
+          python-version: 3.9
           mamba-version: "*"
           channels: conda-forge,defaults
           channel-priority: true
-          activate-environment: anaconda-client-env
+          activate-environment: mescore
           environment-file: environment.yml
       - shell: bash -l {0}
         run: |
@@ -30,7 +30,11 @@ jobs:
           conda config --show
           printenv | sort
       - shell: bash -l {0}
-        run: mamba install jupyterlab
+        run: |
+          conda activate mescore
+          mamba install pytest
+          caimanmanager.py install
+          
 
 
 # on: [push]

--- a/.github/workflows/conda-windows.yaml
+++ b/.github/workflows/conda-windows.yaml
@@ -21,7 +21,7 @@ jobs:
           micromamba activate mescore
           caimanmanager.py install
           micromamba install pytest
-          pip install "https://pypi.anaconda.org/scipy-wheels-nightly/simple/pandas/1.5.0.dev0%2B1172.ga7c5773d19/pandas-1.5.0.dev0%2B1172.ga7c5773d19-cp39-cp39-win_amd64.whl"
+          pip install "https://pypi.anaconda.org/scipy-wheels-nightly/simple/pandas/1.5.0.dev0%2B1188.g8c7b0b2684/pandas-1.5.0.dev0%2B1188.g8c7b0b2684-cp310-cp310-win_amd64.whl"
           pip install .
           
       - name: pytests

--- a/.github/workflows/conda-windows.yaml
+++ b/.github/workflows/conda-windows.yaml
@@ -1,0 +1,42 @@
+name: Python Package using Conda
+
+on: [push]
+
+jobs:
+  build-linux:
+    runs-on: windows-10
+    strategy:
+      max-parallel: 5
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v3
+      with:
+        python-version: 3.9
+    - name: Add conda to system path
+      run: |
+        # $CONDA is an environment variable pointing to the root of the miniconda directory
+        echo $CONDA/bin >> $GITHUB_PATH
+        
+    - name: Install mamba
+      run: |
+        conda install -c conda-forge mamba
+        conda clean -a
+        
+        #   - name: install caiman
+        #     run: |
+        #       mamba install -c conda-forge caiman
+        
+    - name: install mesmerize-core
+      run: |
+        mamba env update -n base --file environment.yml
+        caimanmanager.py install
+        pip install git+https://github.com/pandas-dev/pandas.git
+        pip install .
+        
+    - name: Test with pytest
+      run: |
+        mamba install pytest
+        $env:DOWNLOAD_GROUND_TRUTHS="1" pytest -s .
+        

--- a/.github/workflows/conda-windows.yaml
+++ b/.github/workflows/conda-windows.yaml
@@ -9,12 +9,15 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install Conda environment from environment.yml
         uses: mamba-org/provision-with-micromamba@main
-          with:
-            environment-name: mescore
+        with:
+          environment-file: environment.yml
+          environment-name: mescore
+
         
       - name: Run Python
         shell: bash -l {0}
         run: |
+          conda activate mescore
           caimanmanager.py install
 
 # jobs:

--- a/.github/workflows/conda-windows.yaml
+++ b/.github/workflows/conda-windows.yaml
@@ -14,11 +14,19 @@ jobs:
           environment-name: mescore
 
         
-      - name: Run Python
+      - name: install mesmerize
         shell: bash -l {0}
         run: |
           micromamba activate mescore
           caimanmanager.py install
+          micromamba install pytest
+          pip install "https://pypi.anaconda.org/scipy-wheels-nightly/simple/pandas/1.5.0.dev0%2B1172.ga7c5773d19/pandas-1.5.0.dev0%2B1172.ga7c5773d19-cp39-cp39-win_amd64.whl"
+          pip install .
+      - name: pytests
+        shell: bash -l {0}
+        run: |
+          micromamba activate mescore
+          export DOWNLOAD_GROUND_TRUTHS=1 pytest -s .
 
 # jobs:
 #   build-windows:

--- a/.github/workflows/conda-windows.yaml
+++ b/.github/workflows/conda-windows.yaml
@@ -1,10 +1,10 @@
-name: Python Package using Conda
+name: Windows Conda
 
 on: [push]
 
 jobs:
   build-linux:
-    runs-on: windows-10
+    runs-on: windows-latest
     strategy:
       max-parallel: 5
 

--- a/.github/workflows/conda-windows.yaml
+++ b/.github/workflows/conda-windows.yaml
@@ -13,7 +13,7 @@ jobs:
           environment-file: environment.yml
           environment-name: mescore
           extra-specs: |
-            python=3.9
+            python=3.10
 
       - name: install mesmerize
         shell: bash -l {0}

--- a/.github/workflows/conda-windows.yaml
+++ b/.github/workflows/conda-windows.yaml
@@ -12,8 +12,8 @@ jobs:
         with:
           environment-file: environment.yml
           environment-name: mescore
-           extra-specs: |
-             python=3.8
+          extra-specs: |
+            python=3.8
 
       - name: install mesmerize
         shell: bash -l {0}

--- a/.github/workflows/conda-windows.yaml
+++ b/.github/workflows/conda-windows.yaml
@@ -15,11 +15,13 @@ jobs:
       with:
         python-version: 3.9
     - name: Add conda to system path
+      shell: bash -l {0}
       run: |
         # $CONDA is an environment variable pointing to the root of the miniconda directory
         echo $CONDA/bin >> $GITHUB_PATH
         
     - name: Install mamba
+      shell: bash -l {0}
       run: |
         conda install -c conda-forge mamba
         conda clean -a
@@ -29,6 +31,7 @@ jobs:
         #       mamba install -c conda-forge caiman
         
     - name: install mesmerize-core
+      shell: bash -l {0}
       run: |
         mamba env update -n base --file environment.yml
         caimanmanager.py install
@@ -36,8 +39,9 @@ jobs:
         pip install .
         
     - name: Test with pytest
+      shell: bash -l {0}
       run: |
         mamba install pytest
-        $env:DOWNLOAD_GROUND_TRUTHS="1"
-        pytest -s .
+        #$env:DOWNLOAD_GROUND_TRUTHS="1"
+        export DOWNLOAD_GROUND_TRUTHS=1 pytest -s .
         

--- a/.github/workflows/conda-windows.yaml
+++ b/.github/workflows/conda-windows.yaml
@@ -24,7 +24,7 @@ jobs:
     - name: install mesmerize-core
       shell: bash -l {0}
       run: |
-        mamba env update -n base --file environment.yml
+        mamba env update -n foo --file environment.yml
         caimanmanager.py install
         pip install "https://pypi.anaconda.org/scipy-wheels-nightly/simple/pandas/1.5.0.dev0%2B1172.ga7c5773d19/pandas-1.5.0.dev0%2B1172.ga7c5773d19-cp39-cp39-win_amd64.whl"
         pip install .

--- a/.github/workflows/conda-windows.yaml
+++ b/.github/workflows/conda-windows.yaml
@@ -2,15 +2,6 @@ name: Windows Conda
 
 on: [push]
 
-# jobs:
-#   build:
-#     runs-on: windows-latest
-#     steps:
-#     - uses: conda-incubator/setup-miniconda@v2
-#     - name: Setup tmate session
-#       uses: mxschmitt/action-tmate@v3
-
-
 jobs:
   build-windows:
     runs-on: windows-latest
@@ -29,18 +20,16 @@ jobs:
         conda info
         conda install -c conda-forge mamba
         conda clean -a
-        
-    - name: setup tmate session
-      uses: mxschmitt/action-tmate@v3
 
     - name: install mesmerize-core
       shell: bash -l {0}
       run: |
+        mamba env update --file environment.yml
         #mamba create -n mescore --file environment.yml
         # mamba env update -n foo --file environment.yml
         caimanmanager.py install
-        #pip install "https://pypi.anaconda.org/scipy-wheels-nightly/simple/pandas/1.5.0.dev0%2B1172.ga7c5773d19/pandas-1.5.0.dev0%2B1172.ga7c5773d19-cp39-cp39-win_amd64.whl"
-        #pip install .
+        pip install "https://pypi.anaconda.org/scipy-wheels-nightly/simple/pandas/1.5.0.dev0%2B1172.ga7c5773d19/pandas-1.5.0.dev0%2B1172.ga7c5773d19-cp39-cp39-win_amd64.whl"
+        pip install .
 
     - name: Test with pytest
       shell: bash -l {0}

--- a/environment.yml
+++ b/environment.yml
@@ -1,8 +1,7 @@
 channels:
   - conda-forge
 dependencies:
-  - caiman
+  - caiman >= 1.9.11
   - pandas
   - requests
   - click
-

--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,7 @@
 channels:
   - conda-forge
 dependencies:
-  - caiman >= 1.9.10
+  - caiman
   - pandas
   - requests
   - click

--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,7 @@
 channels:
   - conda-forge
 dependencies:
-  - caiman >= 1.9.11
+  - caiman
   - pandas
   - requests
   - click

--- a/mesmerize_core/algorithms/cnmf.py
+++ b/mesmerize_core/algorithms/cnmf.py
@@ -13,6 +13,7 @@ from shutil import move as move_file
 # prevent circular import
 if __name__ == "__main__":
     from mesmerize_core import set_parent_raw_data_path, load_batch
+    from mesmerize_core.utils import IS_WINDOWS
 
 
 @click.command()
@@ -97,7 +98,8 @@ def main(batch_path, uuid, data_path: str = None):
         d = dict()
 
         cnmf_memmap_path = output_dir.joinpath(Path(fname_new).name)
-
+        if IS_WINDOWS:
+            Yr._mmap.close()  # accessing private attr but windows is annoying otherwise
         move_file(fname_new, cnmf_memmap_path)
 
         cnmf_hdf5_path = output_path.relative_to(output_dir.parent)

--- a/mesmerize_core/algorithms/cnmfe.py
+++ b/mesmerize_core/algorithms/cnmfe.py
@@ -11,6 +11,7 @@ from shutil import move as move_file
 
 if __name__ == "__main__":
     from mesmerize_core import set_parent_raw_data_path, load_batch
+    from mesmerize_core.utils import IS_WINDOWS
 
 
 @click.command()
@@ -104,7 +105,8 @@ def main(batch_path, uuid, data_path: str = None):
                 )
 
         cnmf_memmap_path = output_dir.joinpath(Path(fname_new).name)
-
+        if IS_WINDOWS:
+            Yr._mmap.close()  # accessing private attr but windows is annoying otherwise
         move_file(fname_new, cnmf_memmap_path)
 
         cnmfe_memmap_path = cnmf_memmap_path.relative_to(output_dir.parent)

--- a/mesmerize_core/utils.py
+++ b/mesmerize_core/utils.py
@@ -14,6 +14,7 @@ from typing import *
 import re as regex
 from pathlib import Path
 from warnings import warn
+import sys
 
 
 if os.name == "nt":
@@ -236,9 +237,11 @@ def make_runfile(
     else:
         with open(sh_file, "w") as f:
             for k, v in os.environ.items():  # copy the current environment
+                if regex.match("^.*[\(\)]", str(k)) or regex.match("^.*[\(\)]", str(v)):
+                    continue
                 f.write(f'$env:{k}="{v}";\n')
 
-            f.write(f"python {module_path} {args_str}")
+            f.write(f"{sys.executable} {module_path} {args_str}")
 
     st = os.stat(sh_file)
     os.chmod(sh_file, st.st_mode | S_IEXEC)

--- a/mesmerize_core/utils.py
+++ b/mesmerize_core/utils.py
@@ -236,6 +236,7 @@ def make_runfile(
 
     else:
         with open(sh_file, "w") as f:
+            f.write("$ErrorActionPreference = 'SilentlyContinue'\n")
             for k, v in os.environ.items():  # copy the current environment
                 if regex.match("^.*[\(\)]", str(k)) or regex.match("^.*[\(\)]", str(v)):
                     continue

--- a/mesmerize_core/utils.py
+++ b/mesmerize_core/utils.py
@@ -15,7 +15,7 @@ import re as regex
 from pathlib import Path
 from warnings import warn
 import sys
-import tempfile
+from tempfile import NamedTemporaryFile
 from subprocess import check_call
 
 if os.name == "nt":
@@ -240,7 +240,7 @@ def make_runfile(
             for k, v in os.environ.items():  # copy the current environment
                 if regex.match("^.*[\(\)]", str(k)) or regex.match("^.*[\(\)]", str(v)):
                     continue
-                 with NamedTemporaryFile(suffix=".ps1", delete=False) as tmp:
+                with NamedTemporaryFile(suffix=".ps1", delete=False) as tmp:
                     try:  # windows powershell is stupid so make sure all the env var names work
                         tmp.write(f'$env:{k}="{v}";\n')
                         tmp.close()


### PR DESCRIPTION
works on windows, fixes #56 and other annoying things

windows is extremely weird, together with the lack of a proper API for caiman which requires files to be moved around after an algo is run (since it's not possible to tell caiman where to put output files), and then windows doesn't like moving the files after so a method from a private attribute needs to be called to close the memmap instance. this is very bad but whatever ¯\\\_(ツ)_/¯ https://github.com/numpy/numpy/issues/13510#issuecomment-552481639 

also added windows github action to CI pipeline 