### PR TITLE
safety check to prevent small sub dataframe from overwriting full dataframe on disk

### DIFF
--- a/mesmerize_core/caiman_extensions/common.py
+++ b/mesmerize_core/caiman_extensions/common.py
@@ -20,6 +20,7 @@ from ..batch_utils import (
     COMPUTE_BACKEND_SUBPROCESS,
     ALGO_MODULES,
     get_parent_raw_data_path,
+    load_batch
 )
 from ..utils import validate_path, IS_WINDOWS, make_runfile, warning_experimental
 from caiman import load_memmap
@@ -111,11 +112,26 @@ class CaimanDataFrameExtensions:
         # Save DataFrame to disk
         self._df.to_pickle(self._df.paths.get_batch_path())
 
-    def save_to_disk(self):
+    def save_to_disk(self, max_index_diff: int = 0):
         """
         Saves DataFrame to disk, copies to a backup before overwriting existing file.
         """
         path: Path = self._df.paths.get_batch_path()
+
+        disk_df = load_batch(path)
+
+        # check that max_index_diff is not exceeded
+        if abs(disk_df.index.size - self._df.index.size) > max_index_diff:
+            raise IndexError(
+                f"The number of rows in the DataFrame on disk differs more "
+                f"than has been allowed by the `max_index_diff` kwarg which "
+                f"is set to <{max_index_diff}>. This is to prevent overwriting "
+                f"the full DataFrame with a sub-DataFrame. If you still wish "
+                f"to save the smaller DataFrame, use `caiman.save_to_disk()` "
+                f"with `max_index_diff` set to the highest allowable difference "
+                f"in row number."
+            )
+
         bak = path.with_suffix(path.suffix + f"bak.{time()}")
 
         shutil.copyfile(path, bak)


### PR DESCRIPTION
Addresses #125 

Since a DataFrame batch path is propogated to any "sub dataframes" created by fancy indexing or other means, this prevents the existing full dataframe on disk from being overwritten by the smaller sub dataframe.

For example:
```python3
from mesmerize_core import *

df = load_batch("/path/to/batch.pickle")

# create a sub dataframe
sub_df = df[df["algo"] == "cnmf"]

# this is dangerous! So this PR would prevent it.
sub_df.save_to_disk()
```

User can still override with the `max_index_diff` kwarg:

```python3
# forced save if number of rows doesn't differ by more than 5
sub_df.save_to_disk(max_index_diff=5)
```