### PR TITLE
fixing bug in time()

### DIFF
--- a/mesmerize_core/caiman_extensions/common.py
+++ b/mesmerize_core/caiman_extensions/common.py
@@ -8,6 +8,7 @@ from shutil import rmtree
 from itertools import chain
 from collections import Counter
 from datetime import datetime
+import time
 
 import numpy as np
 import pandas as pd
@@ -149,7 +150,7 @@ class CaimanDataFrameExtensions:
                 f"in row number."
             )
 
-        bak = path.with_suffix(path.suffix + f"bak.{time()}")
+        bak = path.with_suffix(path.suffix + f"bak.{time.time()}")
 
         shutil.copyfile(path, bak)
         try:


### PR DESCRIPTION
addresses #165

I think this is what you want, I created a new batch and saved/reloaded from disk and it worked

I think the issue had to do with using `datetime.time()` for formatting in added/ran time columns of a dataframe vs saving the `time.time()` when saving a dataframe to disk
