### PR TITLE
allow manually setting shape

### DIFF
--- a/mesmerize_core/arrays/_tiff.py
+++ b/mesmerize_core/arrays/_tiff.py
@@ -9,7 +9,7 @@ from ._base import LazyArray
 
 
 class LazyTiff(LazyArray):
-    def __init__(self, path: Union[Path, str]):
+    def __init__(self, path: Union[Path, str], shape: Tuple[int] = None):
         """
         Lazy reader for tiff files. WIP, works for some tiff files.
         Try ``tifffile.memmap`` first before trying ``LazyTiff``
@@ -18,18 +18,25 @@ class LazyTiff(LazyArray):
         ----------
         path: str or Path
             path to tiff file
+
+        shape: Tuple[int]
+            manually set shape
         """
 
         self._tif = tifffile.TiffFile(path)
         tiffseries = self._tif.series[0].levels[0]
 
-        # TODO: someone who's better with tiff can help on this
-        if len(self._tif.pages) == 1:
-            n_frames = len(self._tif.series)
-        else:
-            n_frames = len(self._tif.pages)
+        if shape is None:
+            # TODO: someone who's better with tiff can help on this
+            if len(self._tif.pages) == 1:
+                n_frames = len(self._tif.series)
+            else:
+                n_frames = len(self._tif.pages)
 
-        self._shape = (n_frames, *tiffseries.shape)
+            self._shape = (n_frames, *tiffseries.shape)
+        else:
+            self._shape = shape
+
         self._dtype = tiffseries.dtype.name
 
     @property


### PR DESCRIPTION
partly addresses #178 

Allows manually setting the shape when using LazyTiff if known.

Example:

```python
from mesmerize_core import *
from mesmerize_core.arrays import LazyTiff
from fastplotlib.widgets import ImageWidget

# set parent data path, load batch as `df`

def load_tiff(path):
  tif = tifffile.TiffFile(path)  # create tiff object

  # sometimes you can get the shape like this, but it varies depending on your filetyep
  # explore the structure of your tif to determine how to get the shape
  s = tif.series[0].level[0].shape
  # return lazy tiff instance
  return LazyTiff(path, shape=s)

input_movie = df.iloc[0].caiman.get_input(load_tiff)

iw = ImageWidget(data=input_movie)
iw.show()
```