### PR TITLE
playing with pynapple

### DIFF
--- a/mesmerize_core/caiman_extensions/_pynapple.py
+++ b/mesmerize_core/caiman_extensions/_pynapple.py
@@ -1,0 +1,37 @@
+import numpy as np
+import pandas as pd
+import pynapple as nap
+from caiman.source_extraction.cnmf import CNMF
+
+
+from ._utils import validate
+from .cnmf import CNMFExtensions
+
+
+@pd.api.extensions.register_series_accessor("nap")
+class PynappleExtension:
+    def __init__(self, series: pd.Series):
+        self._series = series
+
+    @validate("cnmf")
+    def get_tsd_frame(self):
+        cnmf_obj: CNMF = self._series.cnmf.get_output()
+
+        framerate = cnmf_obj.params.data["fr"]
+
+        n_frames = cnmf_obj.estimates.C[1]
+
+        duration_seconds = n_frames / framerate
+
+        timestamps = np.linspace(0, duration_seconds, n_frames)
+
+        n_components = cnmf_obj.estimates.C.shape[0]
+
+        tsdframe = nap.TsdFrame(
+            t=timestamps,
+            d=cnmf_obj.estimates.C.T,
+            time_units="s",
+            columns=list(map(range(n_components)))
+        )
+
+        return tsdframe


### PR DESCRIPTION
Just playing around with it for now.

usage:

```python3
# with a cnmf item
df.iloc[1].nap.get_tsd_frame()

Out[7]: 
Time (s)             0          1         2         3         4         5          6         7         8  ...
------------  --------  ---------  --------  --------  --------  --------  ---------  --------  --------  -----
0.0           -23.5793  -23.1808   -25.6122  -10.6084  -21.208   -6.36728  -10.4701   -13.5863  -12.1918  ...
0.033344448   -23.5793  -23.1808   -25.6122  -10.6084  -21.208   -6.36728  -10.4701   -13.5863  -12.1918  ...
0.066688896   -23.5793    9.57066  -25.6122  -10.6084  -21.208   -6.36728  -10.4701   -13.5863  -12.1918  ...
0.100033344   -23.5793    7.42798  -25.6122  -10.6084  -21.208   -6.36728  -10.4701   -13.5863  -12.1918  ...
0.133377793   -23.5793    4.76448  -25.6122  -10.6084  -21.208   -6.36728  -10.4701   -13.5863  -12.1918  ...
...
99.866622207  -23.5793  -23.1598   -22.9783  -10.6     -19.953   -6.36728   -9.36472  -13.5456  -12.1918  ...
99.899966656  -23.5793  -23.1617   -23.1542  -10.6009  -20.0842  -6.36728   -9.46171  -13.5496  -12.1918  ...
99.933311104  -23.5793  -23.1633   -23.3184  -10.6016  -20.2018  -6.36728   -9.55019  -13.5531  -12.1918  ...
99.966655552  -23.5793  -23.1648   -23.4716  -10.6023  -20.307   -6.36728   -9.6309   -13.5564  -12.1918  ...
100.0         -23.5793  -23.1662   -23.6146  -10.6029  -20.4012  -6.36728   -9.70454  -13.5593  -12.1918  ...
dtype: float64, shape: (3000, 155)
```