### PR TITLE
int32 not sufficient for nbytes

### DIFF
--- a/mesmerize_core/arrays/_base.py
+++ b/mesmerize_core/arrays/_base.py
@@ -71,7 +71,7 @@ class LazyArray(ABC):
         int
             number of bytes for the array if it were fully computed
         """
-        return np.prod(self.shape + (np.dtype(self.dtype).itemsize,))
+        return np.prod(self.shape + (np.dtype(self.dtype).itemsize,), dtype=np.int64)
 
     @property
     def nbytes_gb(self) -> float:


### PR DESCRIPTION
dtype of self.nbytes defaults to int32, which is not sufficient for larger datasets.

E.g. 

```
>> shape = (26191, 512, 512)
>> itemsize = 8
>> np.prod(shape + (itemsize,), dtype=np.int32)
-908066816

>> np.prod(shape + (itemsize,), dtype=np.int64)
54926508032
```

