### PR TITLE
Run items using SLURM; save batches with platform-independent paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,4 +134,4 @@ dmypy.json
 # test files
 tests/tmp
 tests/videos
-
+tests/ground_truths*

--- a/environment.yml
+++ b/environment.yml
@@ -8,4 +8,4 @@ dependencies:
   - jupyterlab
   - tqdm
   - psutil
-  - filelock
+  - filelock >= 3.15.1

--- a/environment.yml
+++ b/environment.yml
@@ -8,3 +8,4 @@ dependencies:
   - jupyterlab
   - tqdm
   - psutil
+  - filelock

--- a/environment_rtd.yml
+++ b/environment_rtd.yml
@@ -8,4 +8,4 @@ dependencies:
   - tqdm
   - psutil
   - pydata-sphinx-theme < 0.10.0
-  - filelock
+  - filelock >= 3.15.1

--- a/environment_rtd.yml
+++ b/environment_rtd.yml
@@ -8,3 +8,4 @@ dependencies:
   - tqdm
   - psutil
   - pydata-sphinx-theme < 0.10.0
+  - filelock

--- a/mesmerize_core/__init__.py
+++ b/mesmerize_core/__init__.py
@@ -3,6 +3,7 @@ from .batch_utils import (
     get_parent_raw_data_path,
     load_batch,
     create_batch,
+    save_results_safely
 )
 from .caiman_extensions import *
 from pathlib import Path
@@ -16,6 +17,7 @@ __all__ = [
     "get_parent_raw_data_path",
     "load_batch",
     "create_batch",
+    "save_results_safely",
     "CaimanDataFrameExtensions",
     "CaimanSeriesExtensions",
     "CNMFExtensions",

--- a/mesmerize_core/__init__.py
+++ b/mesmerize_core/__init__.py
@@ -3,7 +3,6 @@ from .batch_utils import (
     get_parent_raw_data_path,
     load_batch,
     create_batch,
-    save_results_safely
 )
 from .caiman_extensions import *
 from pathlib import Path
@@ -17,7 +16,6 @@ __all__ = [
     "get_parent_raw_data_path",
     "load_batch",
     "create_batch",
-    "save_results_safely",
     "CaimanDataFrameExtensions",
     "CaimanSeriesExtensions",
     "CNMFExtensions",

--- a/mesmerize_core/algorithms/cnmf.py
+++ b/mesmerize_core/algorithms/cnmf.py
@@ -13,10 +13,10 @@ import time
 
 # prevent circular import
 if __name__ in ["__main__", "__mp_main__"]:  # when running in subprocess
-    from mesmerize_core import set_parent_raw_data_path, load_batch, save_results_safely
+    from mesmerize_core import set_parent_raw_data_path, load_batch
     from mesmerize_core.utils import IS_WINDOWS
 else:  # when running with local backend
-    from ..batch_utils import set_parent_raw_data_path, load_batch, save_results_safely
+    from ..batch_utils import set_parent_raw_data_path, load_batch
     from ..utils import IS_WINDOWS
 
 
@@ -25,7 +25,7 @@ def run_algo(batch_path, uuid, data_path: str = None):
     set_parent_raw_data_path(data_path)
 
     df = load_batch(batch_path)
-    item = df[df["uuid"] == uuid].squeeze()
+    item = df.caiman.uloc(uuid)
 
     input_movie_path = item["input_movie_path"]
     # resolve full path
@@ -138,7 +138,7 @@ def run_algo(batch_path, uuid, data_path: str = None):
     cm.stop_server(dview=dview)
     
     runtime = round(time.time() - algo_start, 2)
-    save_results_safely(batch_path, uuid, d, runtime)
+    df.caiman.update_item_with_results(uuid, d, runtime)
 
 @click.command()
 @click.option("--batch-path", type=str)

--- a/mesmerize_core/algorithms/cnmf.py
+++ b/mesmerize_core/algorithms/cnmf.py
@@ -12,7 +12,7 @@ from shutil import move as move_file
 import os
 import time
 from datetime import datetime
-from filelock import FileLock, Timeout
+from filelock import SoftFileLock, Timeout
 
 # prevent circular import
 if __name__ in ["__main__", "__mp_main__"]:  # when running in subprocess
@@ -140,7 +140,7 @@ def run_algo(batch_path, uuid, data_path: str = None):
     cm.stop_server(dview=dview)
 
     # lock batch file while writing back results
-    batch_lock = FileLock(batch_path + '.lock', timeout=30)
+    batch_lock = SoftFileLock(batch_path + '.lock', timeout=30)
     try:
         with batch_lock:
             df = load_batch(batch_path)

--- a/mesmerize_core/algorithms/cnmf.py
+++ b/mesmerize_core/algorithms/cnmf.py
@@ -12,6 +12,7 @@ from shutil import move as move_file
 import os
 import time
 from datetime import datetime
+from filelock import FileLock, Timeout
 
 # prevent circular import
 if __name__ in ["__main__", "__mp_main__"]:  # when running in subprocess
@@ -138,13 +139,29 @@ def run_algo(batch_path, uuid, data_path: str = None):
 
     cm.stop_server(dview=dview)
 
-    # Add dictionary to output column of series
-    df.loc[df["uuid"] == uuid, "outputs"] = [d]
-    # Add ran timestamp to ran_time column of series
-    df.loc[df["uuid"] == uuid, "ran_time"] = datetime.now().isoformat(timespec="seconds", sep="T")
-    df.loc[df["uuid"] == uuid, "algo_duration"] = str(round(time.time() - algo_start, 2)) + " sec"
-    # save dataframe to disc
-    df.to_pickle(batch_path)
+    # lock batch file while writing back results
+    batch_lock = FileLock(batch_path + '.lock', timeout=30)
+    try:
+        with batch_lock:
+            df = load_batch(batch_path)
+
+            # Add dictionary to output column of series
+            df.loc[df["uuid"] == uuid, "outputs"] = [d]
+            # Add ran timestamp to ran_time column of series
+            df.loc[df["uuid"] == uuid, "ran_time"] = datetime.now().isoformat(timespec="seconds", sep="T")
+            df.loc[df["uuid"] == uuid, "algo_duration"] = str(round(time.time() - algo_start, 2)) + " sec"
+            # save dataframe to disc
+            df.to_pickle(batch_path)
+    except Timeout:
+        # Print a message with details in lieu of writing to the batch file
+        msg = f"Batch file could not be written to within {batch_lock.timeout} seconds."
+        if d["success"]:
+            msg += f"\nRun succeeded; results are in {output_dir}."
+        else:
+            msg += f"Run failed. Traceback:\n"
+            msg += d["traceback"]
+
+        raise RuntimeError(msg)
 
 
 @click.command()

--- a/mesmerize_core/algorithms/cnmf.py
+++ b/mesmerize_core/algorithms/cnmf.py
@@ -113,7 +113,7 @@ def run_algo(batch_path, uuid, data_path: str = None):
             Yr._mmap.close()  # accessing private attr but windows is annoying otherwise
         move_file(fname_new, cnmf_memmap_path)
 
-        # save paths as realative path strings with forward slashes
+        # save paths as relative path strings with forward slashes
         cnmf_hdf5_path = str(PurePosixPath(output_path.relative_to(output_dir.parent)))
         cnmf_memmap_path = str(PurePosixPath(cnmf_memmap_path.relative_to(output_dir.parent)))
         corr_img_path = str(PurePosixPath(corr_img_path.relative_to(output_dir.parent)))

--- a/mesmerize_core/algorithms/cnmf.py
+++ b/mesmerize_core/algorithms/cnmf.py
@@ -7,7 +7,7 @@ import psutil
 import numpy as np
 import pandas as pd
 import traceback
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from shutil import move as move_file
 import os
 import time
@@ -116,13 +116,14 @@ def run_algo(batch_path, uuid, data_path: str = None):
             Yr._mmap.close()  # accessing private attr but windows is annoying otherwise
         move_file(fname_new, cnmf_memmap_path)
 
-        cnmf_hdf5_path = output_path.relative_to(output_dir.parent)
-        cnmf_memmap_path = cnmf_memmap_path.relative_to(output_dir.parent)
-        corr_img_path = corr_img_path.relative_to(output_dir.parent)
+        # save paths as realative path strings with forward slashes
+        cnmf_hdf5_path = str(PurePosixPath(output_path.relative_to(output_dir.parent)))
+        cnmf_memmap_path = str(PurePosixPath(cnmf_memmap_path.relative_to(output_dir.parent)))
+        corr_img_path = str(PurePosixPath(corr_img_path.relative_to(output_dir.parent)))
         for proj_type in proj_paths.keys():
-            d[f"{proj_type}-projection-path"] = proj_paths[proj_type].relative_to(
+            d[f"{proj_type}-projection-path"] = str(PurePosixPath(proj_paths[proj_type].relative_to(
                 output_dir.parent
-            )
+            )))
 
         d.update(
             {

--- a/mesmerize_core/algorithms/cnmf.py
+++ b/mesmerize_core/algorithms/cnmf.py
@@ -5,21 +5,18 @@ from caiman.source_extraction.cnmf import cnmf as cnmf
 from caiman.source_extraction.cnmf.params import CNMFParams
 import psutil
 import numpy as np
-import pandas as pd
 import traceback
 from pathlib import Path, PurePosixPath
 from shutil import move as move_file
 import os
 import time
-from datetime import datetime
-from filelock import SoftFileLock, Timeout
 
 # prevent circular import
 if __name__ in ["__main__", "__mp_main__"]:  # when running in subprocess
-    from mesmerize_core import set_parent_raw_data_path, load_batch
+    from mesmerize_core import set_parent_raw_data_path, load_batch, save_results_safely
     from mesmerize_core.utils import IS_WINDOWS
 else:  # when running with local backend
-    from ..batch_utils import set_parent_raw_data_path, load_batch
+    from ..batch_utils import set_parent_raw_data_path, load_batch, save_results_safely
     from ..utils import IS_WINDOWS
 
 
@@ -139,31 +136,9 @@ def run_algo(batch_path, uuid, data_path: str = None):
         d = {"success": False, "traceback": traceback.format_exc()}
 
     cm.stop_server(dview=dview)
-
-    # lock batch file while writing back results
-    batch_lock = SoftFileLock(batch_path + '.lock', timeout=30)
-    try:
-        with batch_lock:
-            df = load_batch(batch_path)
-
-            # Add dictionary to output column of series
-            df.loc[df["uuid"] == uuid, "outputs"] = [d]
-            # Add ran timestamp to ran_time column of series
-            df.loc[df["uuid"] == uuid, "ran_time"] = datetime.now().isoformat(timespec="seconds", sep="T")
-            df.loc[df["uuid"] == uuid, "algo_duration"] = str(round(time.time() - algo_start, 2)) + " sec"
-            # save dataframe to disc
-            df.to_pickle(batch_path)
-    except Timeout:
-        # Print a message with details in lieu of writing to the batch file
-        msg = f"Batch file could not be written to within {batch_lock.timeout} seconds."
-        if d["success"]:
-            msg += f"\nRun succeeded; results are in {output_dir}."
-        else:
-            msg += f"Run failed. Traceback:\n"
-            msg += d["traceback"]
-
-        raise RuntimeError(msg)
-
+    
+    runtime = round(time.time() - algo_start, 2)
+    save_results_safely(batch_path, uuid, d, runtime)
 
 @click.command()
 @click.option("--batch-path", type=str)

--- a/mesmerize_core/algorithms/cnmfe.py
+++ b/mesmerize_core/algorithms/cnmfe.py
@@ -105,7 +105,7 @@ def run_algo(batch_path, uuid, data_path: str = None):
             Yr._mmap.close()  # accessing private attr but windows is annoying otherwise
         move_file(fname_new, cnmf_memmap_path)
 
-        # save path as realative path strings with forward slashes
+        # save path as relative path strings with forward slashes
         cnmfe_memmap_path = str(PurePosixPath(cnmf_memmap_path.relative_to(output_dir.parent)))
 
         d.update(

--- a/mesmerize_core/algorithms/cnmfe.py
+++ b/mesmerize_core/algorithms/cnmfe.py
@@ -11,10 +11,10 @@ import os
 import time
 
 if __name__ in ["__main__", "__mp_main__"]:  # when running in subprocess
-    from mesmerize_core import set_parent_raw_data_path, load_batch, save_results_safely
+    from mesmerize_core import set_parent_raw_data_path, load_batch
     from mesmerize_core.utils import IS_WINDOWS
 else:  # when running with local backend
-    from ..batch_utils import set_parent_raw_data_path, load_batch, save_results_safely
+    from ..batch_utils import set_parent_raw_data_path, load_batch
     from ..utils import IS_WINDOWS
 
 
@@ -23,7 +23,7 @@ def run_algo(batch_path, uuid, data_path: str = None):
     set_parent_raw_data_path(data_path)
 
     df = load_batch(batch_path)
-    item = df[df["uuid"] == uuid].squeeze()
+    item = df.caiman.uloc(uuid)
 
     input_movie_path = item["input_movie_path"]
     # resolve full path
@@ -122,7 +122,7 @@ def run_algo(batch_path, uuid, data_path: str = None):
     cm.stop_server(dview=dview)
 
     runtime = round(time.time() - algo_start, 2)
-    save_results_safely(batch_path, uuid, d, runtime)
+    df.caiman.update_item_with_results(uuid, d, runtime)
 
 
 @click.command()

--- a/mesmerize_core/algorithms/cnmfe.py
+++ b/mesmerize_core/algorithms/cnmfe.py
@@ -9,14 +9,12 @@ from pathlib import Path, PurePosixPath
 from shutil import move as move_file
 import os
 import time
-from datetime import datetime
-from filelock import SoftFileLock, Timeout
 
 if __name__ in ["__main__", "__mp_main__"]:  # when running in subprocess
-    from mesmerize_core import set_parent_raw_data_path, load_batch
+    from mesmerize_core import set_parent_raw_data_path, load_batch, save_results_safely
     from mesmerize_core.utils import IS_WINDOWS
 else:  # when running with local backend
-    from ..batch_utils import set_parent_raw_data_path, load_batch
+    from ..batch_utils import set_parent_raw_data_path, load_batch, save_results_safely
     from ..utils import IS_WINDOWS
 
 
@@ -123,29 +121,8 @@ def run_algo(batch_path, uuid, data_path: str = None):
 
     cm.stop_server(dview=dview)
 
-    # lock batch file while writing back results
-    batch_lock = SoftFileLock(batch_path + '.lock', timeout=30)
-    try:
-        with batch_lock:
-            df = load_batch(batch_path)
-
-            # Add dictionary to output column of series
-            df.loc[df["uuid"] == uuid, "outputs"] = [d]
-            # Add ran timestamp to ran_time column of series
-            df.loc[df["uuid"] == uuid, "ran_time"] = datetime.now().isoformat(timespec="seconds", sep="T")
-            df.loc[df["uuid"] == uuid, "algo_duration"] = str(round(time.time() - algo_start, 2)) + " sec"
-            # save dataframe to disc
-            df.to_pickle(batch_path)
-    except Timeout:
-        # Print a message with details in lieu of writing to the batch file
-        msg = f"Batch file could not be written to within {batch_lock.timeout} seconds."
-        if d["success"]:
-            msg += f"\nRun succeeded; results are in {output_dir}."
-        else:
-            msg += f"Run failed. Traceback:\n"
-            msg += d["traceback"]
-
-        raise RuntimeError(msg)
+    runtime = round(time.time() - algo_start, 2)
+    save_results_safely(batch_path, uuid, d, runtime)
 
 
 @click.command()

--- a/mesmerize_core/algorithms/cnmfe.py
+++ b/mesmerize_core/algorithms/cnmfe.py
@@ -10,7 +10,7 @@ from shutil import move as move_file
 import os
 import time
 from datetime import datetime
-from filelock import FileLock, Timeout
+from filelock import SoftFileLock, Timeout
 
 if __name__ in ["__main__", "__mp_main__"]:  # when running in subprocess
     from mesmerize_core import set_parent_raw_data_path, load_batch
@@ -123,7 +123,7 @@ def run_algo(batch_path, uuid, data_path: str = None):
     cm.stop_server(dview=dview)
 
     # lock batch file while writing back results
-    batch_lock = FileLock(batch_path + '.lock', timeout=30)
+    batch_lock = SoftFileLock(batch_path + '.lock', timeout=30)
     try:
         with batch_lock:
             df = load_batch(batch_path)

--- a/mesmerize_core/algorithms/cnmfe.py
+++ b/mesmerize_core/algorithms/cnmfe.py
@@ -5,7 +5,7 @@ from caiman.source_extraction.cnmf import cnmf as cnmf
 from caiman.source_extraction.cnmf.params import CNMFParams
 import psutil
 import traceback
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from shutil import move as move_file
 import os
 import time
@@ -107,7 +107,8 @@ def run_algo(batch_path, uuid, data_path: str = None):
             Yr._mmap.close()  # accessing private attr but windows is annoying otherwise
         move_file(fname_new, cnmf_memmap_path)
 
-        cnmfe_memmap_path = cnmf_memmap_path.relative_to(output_dir.parent)
+        # save path as realative path strings with forward slashes
+        cnmfe_memmap_path = str(PurePosixPath(cnmf_memmap_path.relative_to(output_dir.parent)))
 
         d.update(
             {

--- a/mesmerize_core/algorithms/mcorr.py
+++ b/mesmerize_core/algorithms/mcorr.py
@@ -123,7 +123,7 @@ def run_algo(batch_path, uuid, data_path: str = None):
             shift_path = output_dir.joinpath(f"{uuid}_shifts.npy")
             np.save(str(shift_path), shifts)
 
-        # save paths as realative path strings with forward slashes
+        # save paths as relative path strings with forward slashes
         cn_path = str(PurePosixPath(cn_path.relative_to(output_dir.parent)))
         mcorr_memmap_path = str(PurePosixPath(mcorr_memmap_path.relative_to(output_dir.parent)))
         shift_path = str(PurePosixPath(shift_path.relative_to(output_dir.parent)))

--- a/mesmerize_core/algorithms/mcorr.py
+++ b/mesmerize_core/algorithms/mcorr.py
@@ -12,7 +12,7 @@ import numpy as np
 from shutil import move as move_file
 import time
 from datetime import datetime
-from filelock import FileLock, Timeout
+from filelock import SoftFileLock, Timeout
 
 
 # prevent circular import
@@ -150,7 +150,7 @@ def run_algo(batch_path, uuid, data_path: str = None):
     cm.stop_server(dview=dview)
 
     # lock batch file while writing back results
-    batch_lock = FileLock(batch_path + '.lock', timeout=30)
+    batch_lock = SoftFileLock(batch_path + '.lock', timeout=30)
     try:
         with batch_lock:
             df = load_batch(batch_path)

--- a/mesmerize_core/algorithms/mcorr.py
+++ b/mesmerize_core/algorithms/mcorr.py
@@ -12,6 +12,7 @@ import numpy as np
 from shutil import move as move_file
 import time
 from datetime import datetime
+from filelock import FileLock, Timeout
 
 
 # prevent circular import
@@ -148,13 +149,29 @@ def run_algo(batch_path, uuid, data_path: str = None):
 
     cm.stop_server(dview=dview)
 
-    # Add dictionary to output column of series
-    df.loc[df["uuid"] == uuid, "outputs"] = [d]
-    # Add ran timestamp to ran_time column of series
-    df.loc[df["uuid"] == uuid, "ran_time"] = datetime.now().isoformat(timespec="seconds", sep="T")
-    df.loc[df["uuid"] == uuid, "algo_duration"] = str(round(time.time() - algo_start, 2)) + " sec"
-    # Save DataFrame to disk
-    df.to_pickle(batch_path)
+    # lock batch file while writing back results
+    batch_lock = FileLock(batch_path + '.lock', timeout=30)
+    try:
+        with batch_lock:
+            df = load_batch(batch_path)
+
+            # Add dictionary to output column of series
+            df.loc[df["uuid"] == uuid, "outputs"] = [d]
+            # Add ran timestamp to ran_time column of series
+            df.loc[df["uuid"] == uuid, "ran_time"] = datetime.now().isoformat(timespec="seconds", sep="T")
+            df.loc[df["uuid"] == uuid, "algo_duration"] = str(round(time.time() - algo_start, 2)) + " sec"
+            # Save DataFrame to disk
+            df.to_pickle(batch_path)
+    except Timeout:
+        # Print a message with details in lieu of writing to the batch file
+        msg = f"Batch file could not be written to within {batch_lock.timeout} seconds."
+        if d["success"]:
+            msg += f"\nRun succeeded; results are in {output_dir}."
+        else:
+            msg += f"Run failed. Traceback:\n"
+            msg += d["traceback"]
+
+        raise RuntimeError(msg)
 
 
 @click.command()

--- a/mesmerize_core/algorithms/mcorr.py
+++ b/mesmerize_core/algorithms/mcorr.py
@@ -13,9 +13,9 @@ import time
 
 # prevent circular import
 if __name__ in ["__main__", "__mp_main__"]:  # when running in subprocess
-    from mesmerize_core import set_parent_raw_data_path, load_batch, save_results_safely
+    from mesmerize_core import set_parent_raw_data_path, load_batch
 else:  # when running with local backend
-    from ..batch_utils import set_parent_raw_data_path, load_batch, save_results_safely
+    from ..batch_utils import set_parent_raw_data_path, load_batch
 
 
 def run_algo(batch_path, uuid, data_path: str = None):
@@ -25,7 +25,7 @@ def run_algo(batch_path, uuid, data_path: str = None):
     batch_path = Path(batch_path)
     df = load_batch(batch_path)
 
-    item = df[df["uuid"] == uuid].squeeze()
+    item = df.caiman.uloc(uuid)
     # resolve full path
     input_movie_path = str(df.paths.resolve(item["input_movie_path"]))
 
@@ -146,7 +146,7 @@ def run_algo(batch_path, uuid, data_path: str = None):
     cm.stop_server(dview=dview)
 
     runtime = round(time.time() - algo_start, 2)
-    save_results_safely(batch_path, uuid, d, runtime)
+    df.caiman.update_item_with_results(uuid, d, runtime)
 
 
 @click.command()

--- a/mesmerize_core/algorithms/mcorr.py
+++ b/mesmerize_core/algorithms/mcorr.py
@@ -7,7 +7,7 @@ from caiman.summary_images import local_correlations_movie_offline
 import psutil
 import pandas as pd
 import os
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 import numpy as np
 from shutil import move as move_file
 import time
@@ -124,14 +124,14 @@ def run_algo(batch_path, uuid, data_path: str = None):
             shift_path = output_dir.joinpath(f"{uuid}_shifts.npy")
             np.save(str(shift_path), shifts)
 
-        # relative paths
-        cn_path = cn_path.relative_to(output_dir.parent)
-        mcorr_memmap_path = mcorr_memmap_path.relative_to(output_dir.parent)
-        shift_path = shift_path.relative_to(output_dir.parent)
+        # save paths as realative path strings with forward slashes
+        cn_path = str(PurePosixPath(cn_path.relative_to(output_dir.parent)))
+        mcorr_memmap_path = str(PurePosixPath(mcorr_memmap_path.relative_to(output_dir.parent)))
+        shift_path = str(PurePosixPath(shift_path.relative_to(output_dir.parent)))
         for proj_type in proj_paths.keys():
-            d[f"{proj_type}-projection-path"] = proj_paths[proj_type].relative_to(
+            d[f"{proj_type}-projection-path"] = str(PurePosixPath(proj_paths[proj_type].relative_to(
                 output_dir.parent
-            )
+            )))
 
         d.update(
             {

--- a/mesmerize_core/algorithms/mcorr.py
+++ b/mesmerize_core/algorithms/mcorr.py
@@ -5,7 +5,6 @@ from caiman.source_extraction.cnmf.params import CNMFParams
 from caiman.motion_correction import MotionCorrect
 from caiman.summary_images import local_correlations_movie_offline
 import psutil
-import pandas as pd
 import os
 from pathlib import Path, PurePosixPath
 import numpy as np
@@ -17,9 +16,9 @@ from filelock import SoftFileLock, Timeout
 
 # prevent circular import
 if __name__ in ["__main__", "__mp_main__"]:  # when running in subprocess
-    from mesmerize_core import set_parent_raw_data_path, load_batch
+    from mesmerize_core import set_parent_raw_data_path, load_batch, save_results_safely
 else:  # when running with local backend
-    from ..batch_utils import set_parent_raw_data_path, load_batch
+    from ..batch_utils import set_parent_raw_data_path, load_batch, save_results_safely
 
 
 def run_algo(batch_path, uuid, data_path: str = None):
@@ -149,29 +148,8 @@ def run_algo(batch_path, uuid, data_path: str = None):
 
     cm.stop_server(dview=dview)
 
-    # lock batch file while writing back results
-    batch_lock = SoftFileLock(batch_path + '.lock', timeout=30)
-    try:
-        with batch_lock:
-            df = load_batch(batch_path)
-
-            # Add dictionary to output column of series
-            df.loc[df["uuid"] == uuid, "outputs"] = [d]
-            # Add ran timestamp to ran_time column of series
-            df.loc[df["uuid"] == uuid, "ran_time"] = datetime.now().isoformat(timespec="seconds", sep="T")
-            df.loc[df["uuid"] == uuid, "algo_duration"] = str(round(time.time() - algo_start, 2)) + " sec"
-            # Save DataFrame to disk
-            df.to_pickle(batch_path)
-    except Timeout:
-        # Print a message with details in lieu of writing to the batch file
-        msg = f"Batch file could not be written to within {batch_lock.timeout} seconds."
-        if d["success"]:
-            msg += f"\nRun succeeded; results are in {output_dir}."
-        else:
-            msg += f"Run failed. Traceback:\n"
-            msg += d["traceback"]
-
-        raise RuntimeError(msg)
+    runtime = round(time.time() - algo_start, 2)
+    save_results_safely(batch_path, uuid, d, runtime)
 
 
 @click.command()

--- a/mesmerize_core/algorithms/mcorr.py
+++ b/mesmerize_core/algorithms/mcorr.py
@@ -10,9 +10,6 @@ from pathlib import Path, PurePosixPath
 import numpy as np
 from shutil import move as move_file
 import time
-from datetime import datetime
-from filelock import SoftFileLock, Timeout
-
 
 # prevent circular import
 if __name__ in ["__main__", "__mp_main__"]:  # when running in subprocess

--- a/mesmerize_core/batch_utils.py
+++ b/mesmerize_core/batch_utils.py
@@ -10,7 +10,7 @@ CURRENT_BATCH_PATH: Path = None  # only one batch at a time
 PARENT_DATA_PATH: Path = None
 
 COMPUTE_BACKEND_SUBPROCESS = "subprocess"  #: subprocess backend
-COMPUTE_BACKEND_SLURM = "slurm"  #: SLURM backend, not yet implemented
+COMPUTE_BACKEND_SLURM = "slurm"  #: SLURM backend
 COMPUTE_BACKEND_LOCAL = "local"
 
 COMPUTE_BACKENDS = [COMPUTE_BACKEND_SUBPROCESS, COMPUTE_BACKEND_SLURM, COMPUTE_BACKEND_LOCAL]

--- a/mesmerize_core/batch_utils.py
+++ b/mesmerize_core/batch_utils.py
@@ -249,13 +249,10 @@ def get_full_raw_data_path(path: Union[Path, str]) -> Path:
     return path
 
 
-class OverwriteError(IndexError):
-    """
-    Error thrown when trying to write to an existing batch file, but there is a risk
-    of overwriting existing data.
-    Note this is a subclass of IndexError to avoid a breaking change, because
-    IndexError was previously thrown from df.caiman.save_to_disk.
-    """
+class PreventOverwriteError(IndexError):
+    """  
+    Error thrown when trying to write to an existing batch file with a potential risk of removing existing rows.  
+    """  
     pass
 
 
@@ -283,7 +280,7 @@ def save_results_safely(batch_path: Union[Path, str], uuid, results: dict, runti
     """
     Try to load the given batch and save results to the given item
     Uses a file lock to ensure that no other process is writing to the same batch using this function,
-    which gives up after lock_timeout seconds (set to -1 to never give up)
+    which gives up after lock_timeout seconds.
     """
     try:
         with open_batch_for_safe_writing(batch_path) as df:
@@ -301,7 +298,7 @@ def save_results_safely(batch_path: Union[Path, str], uuid, results: dict, runti
         msg = f"Batch file could not be written to"
         if isinstance(e, Timeout):
             msg += f" (file locked for {BatchLock.TIMEOUT} seconds)"
-        elif isinstance(e, OverwriteError):
+        elif isinstance(e, PreventOverwriteError):
             msg += f" (items would be overwritten, even though file was locked)"
 
         if results["success"]:

--- a/mesmerize_core/batch_utils.py
+++ b/mesmerize_core/batch_utils.py
@@ -6,7 +6,6 @@ from typing import Union
 from filelock import SoftFileLock, Timeout
 import pandas as pd
 
-from .caiman_extensions.common import OverwriteError
 from .utils import validate_path
 
 CURRENT_BATCH_PATH: Path = None  # only one batch at a time
@@ -248,6 +247,17 @@ def get_full_raw_data_path(path: Union[Path, str]) -> Path:
         return PARENT_DATA_PATH.joinpath(path)
 
     return path
+
+
+class OverwriteError(IndexError):
+    """
+    Error thrown when trying to write to an existing batch file, but there is a risk
+    of overwriting existing data.
+    Note this is a subclass of IndexError to avoid a breaking change, because
+    IndexError was previously thrown from df.caiman.save_to_disk.
+    """
+    pass
+
 
 class BatchLock(SoftFileLock):
     """Locks a batch file for safe writing, returning the dataframe in the 'as' clause"""

--- a/mesmerize_core/batch_utils.py
+++ b/mesmerize_core/batch_utils.py
@@ -262,7 +262,7 @@ class OverwriteError(IndexError):
 class BatchLock(SoftFileLock):
     """Locks a batch file for safe writing, returning the dataframe in the 'as' clause"""
     def __init__(self, batch_path: Union[Path, str], *args, **kwargs):
-        super().__init__(batch_path + ".lock", *args, **kwargs)
+        super().__init__(str(batch_path) + ".lock", *args, **kwargs)
         self.batch_path = batch_path
     
     def __enter__(self) -> pd.DataFrame:

--- a/mesmerize_core/caiman_extensions/_batch_exceptions.py
+++ b/mesmerize_core/caiman_extensions/_batch_exceptions.py
@@ -12,3 +12,10 @@ class WrongAlgorithmExtensionError(Exception):
 
 class DependencyError(Exception):
     pass
+
+
+class PreventOverwriteError(IndexError):
+    """  
+    Error thrown when trying to write to an existing batch file with a potential risk of removing existing rows.  
+    """  
+    pass

--- a/mesmerize_core/caiman_extensions/common.py
+++ b/mesmerize_core/caiman_extensions/common.py
@@ -132,13 +132,13 @@ class CaimanDataFrameExtensions:
         # Save DataFrame to disk
         self.save_to_disk(max_index_diff=1)
 
-    def save_to_disk(self, max_index_diff: int = 0, lock_timeout: float = 1):
+    def save_to_disk(self, max_index_diff: int = 0):
         """
         Saves DataFrame to disk, copies to a backup before overwriting existing file.
         """
         path: Path = self._df.paths.get_batch_path()
 
-        with open_batch_for_safe_writing(path, lock_timeout=lock_timeout) as disk_df:
+        with open_batch_for_safe_writing(path) as disk_df:
             # check that max_index_diff is not exceeded
             if abs(disk_df.index.size - self._df.index.size) > max_index_diff:
                 raise OverwriteError(

--- a/mesmerize_core/caiman_extensions/common.py
+++ b/mesmerize_core/caiman_extensions/common.py
@@ -461,13 +461,9 @@ class CaimanSeriesExtensions:
     def _run_slurm(
         self,
         runfile_path: str,
-        algo: str,
-        uuid,
-        log_dir: Optional[str] = None,
+        log_dir: Optional[Union[str, Path]] = None,
         **kwargs
     ):
-        # raise NotImplementedError("Not yet implemented, just a placeholder")
-
         # this needs to match what's in the runfile
         if 'MESMERIZE_N_PROCESSES' in os.environ:
             n_procs = os.environ['MESMERIZE_N_PROCESSES']
@@ -480,8 +476,8 @@ class CaimanSeriesExtensions:
             log_dir_path = Path(log_dir)
 
         submission_command = (
-            f'sbatch --job-name={algo}-{str(uuid)[:8]} --ntasks=1 --cpus-per-task={n_procs} ' +
-            f'--output={log_dir_path / "slurm-%x.out"} --wrap="{runfile_path}"'
+            f'sbatch --job-name={self._series["algo"]}-{str(self._series["uuid"])[:8]} --ntasks=1 ' +
+            f'--cpus-per-task={n_procs} --output={log_dir_path / "slurm-%x.out"} {runfile_path}'
         )
 
         return Popen(submission_command.split(" "))
@@ -563,8 +559,7 @@ class CaimanSeriesExtensions:
         )
         try:
             self.process = getattr(self, f"_run_{backend}")(
-                runfile_path, wait=wait, uuid=self._series["uuid"],
-                algo=self._series["algo"], **kwargs
+                runfile_path, wait=wait, **kwargs
             )
         except:
             with open(runfile_path, "r") as f:

--- a/mesmerize_core/caiman_extensions/common.py
+++ b/mesmerize_core/caiman_extensions/common.py
@@ -463,6 +463,7 @@ class CaimanSeriesExtensions:
         runfile_path: str,
         algo: str,
         uuid,
+        log_dir: Optional[str] = None,
         **kwargs
     ):
         # raise NotImplementedError("Not yet implemented, just a placeholder")
@@ -473,8 +474,14 @@ class CaimanSeriesExtensions:
         else:
             n_procs = psutil.cpu_count() - 1
 
+        if log_dir is None:
+            log_dir_path = Path(runfile_path).parent
+        else:
+            log_dir_path = Path(log_dir)
+
         submission_command = (
-            f'sbatch --job-name={algo}-{str(uuid)[:8]} --ntasks=1 --cpus-per-task={n_procs} --wrap="{runfile_path}"'
+            f'sbatch --job-name={algo}-{str(uuid)[:8]} --ntasks=1 --cpus-per-task={n_procs} ' +
+            f'--output={log_dir_path / "slurm-%x.out"} --wrap="{runfile_path}"'
         )
 
         return Popen(submission_command.split(" "))

--- a/mesmerize_core/caiman_extensions/common.py
+++ b/mesmerize_core/caiman_extensions/common.py
@@ -462,15 +462,11 @@ class CaimanSeriesExtensions:
         self,
         runfile_path: str,
         wait: bool,
-        log_dir: Optional[Union[str, Path]] = None,
         partition: Optional[Union[str, list[str]]] = None,
         **kwargs
     ):
         """
         Run on a cluster using SLURM. Configurable options (to pass to run):
-        - log_dir: where to store logs of stout/stderr from each job, in files named slurm-{algo}-{uuid8}.out,
-                   where uuid8 is the first 8 characters of the item's UUID. Defaults to the directory containing
-                   the runfile and output dir.
         - partition: if given, tells SLRUM to run the job on the given partition(s).
         """
 
@@ -480,14 +476,15 @@ class CaimanSeriesExtensions:
         else:
             n_procs = psutil.cpu_count() - 1
 
-        if log_dir is None:
-            log_dir_path = Path(runfile_path).parent
-        else:
-            log_dir_path = Path(log_dir)
+        # make sure we have a place to save log files
+        uuid = str(self._series["uuid"])
+        output_dir = Path(runfile_path).parent.joinpath(uuid)
+        output_dir.mkdir(parents=True, exist_ok=True)
+        output_path = output_dir / f'{uuid}.log'
 
         # --wait means that the lifetme of the created process corresponds to the lifetime of the job
-        submission_opts = (f'--job-name={self._series["algo"]}-{str(self._series["uuid"])[:8]} --ntasks=1 ' +
-            f'--cpus-per-task={n_procs} --output={log_dir_path / "slurm-%x.out"} --wait')
+        submission_opts = (f'--job-name={self._series["algo"]}-{uuid[:8]} --ntasks=1 ' +
+            f'--cpus-per-task={n_procs} --output={output_path} --wait')
         
         if partition is not None:
             if isinstance(partition, str):

--- a/mesmerize_core/caiman_extensions/common.py
+++ b/mesmerize_core/caiman_extensions/common.py
@@ -137,7 +137,7 @@ class CaimanDataFrameExtensions:
 
     @_verify_and_lock_batch_file
     @_index_parser
-    def update_item(self, index: int, updates: Union[dict, pd.Series]):
+    def update_item(self, index: Union[int, str, UUID], updates: Union[dict, pd.Series]):
         """
         Update the item at the given index or UUID with the data in updates and write to disk.
 
@@ -214,7 +214,7 @@ class CaimanDataFrameExtensions:
             with self._batch_lock:  # ensure we have the lock to avoid messing up other "safe" operations
                 self._df.to_pickle(path)
             os.remove(bak)
-        except BaseException as err:
+        except (Exception, KeyboardInterrupt) as err:
             shutil.copyfile(bak, path)
             raise IOError(f"Could not save dataframe to disk.") from err
         finally:

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ matplotlib
 click
 psutil
 jupyterlab
+filelock

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ install_requires = [
     "click",
     "psutil",
     "jupyterlab",
+    "filelock"
 ]
 
 


### PR DESCRIPTION
This implements the "slurm" backend via `_run_slurm`. Supports passing a partition or list of partitions on which to run the jobs; more options (such as memory allocation) could be added if we think they're important.

For controlling number of CPUs/processes per job, right now I'm using the MESMERIZE_N_PROCESSES environment variable to indicate how many processes to use *per job*, which matches the behavior of the "subprocess" backend. However, it might be a good idea to instead divide this number by the number of jobs that are running in parallel, to avoid needlessly over-parallelizing each job. I'm doing this in my own code to set the environment variable and it works fine, but it may make sense to automate it.

This also adds a dependency on `filelock` to lock the batch file when updating it to avoid race conditions. I used the `SoftFileLock` because the regular `FileLock` wasn't working for me on a NTFS remote drive (from Linux). As I understand it, this basically just creates a lock file when acquiring and deletes it when releasing, which also wouldn't be hard to implement ourselves if you prefer not to add a dependency.