### PR TITLE
More changes for nested parameters

### DIFF
--- a/mesmerize_core/algorithms/mcorr.py
+++ b/mesmerize_core/algorithms/mcorr.py
@@ -112,7 +112,7 @@ def run_algo(batch_path, uuid, data_path: str = None):
         print("finished computing correlation image")
 
         # Compute shifts
-        if params["main"]["pw_rigid"] == True:
+        if opts.motion["pw_rigid"] == True:
             x_shifts = mc.x_shifts_els
             y_shifts = mc.y_shifts_els
             shifts = [x_shifts, y_shifts]

--- a/mesmerize_core/caiman_extensions/common.py
+++ b/mesmerize_core/caiman_extensions/common.py
@@ -102,11 +102,6 @@ class CaimanDataFrameExtensions:
         # get relative path
         input_movie_path = self._df.paths.split(input_movie_path)[1]
 
-        # convert lists to tuples so that get_params_diffs works
-        for k in list(params["main"].keys()):
-            if isinstance(params["main"][k], list):
-                params["main"][k] = tuple(params["main"][k])
-
         # Create a pandas Series (Row) with the provided arguments
         s = pd.Series(
             {


### PR DESCRIPTION
This has a couple of minor changes. The first is necessary for motion correction to work when parameters are passed as a nested dictionary. The code was assuming that `params["main"]` contains `"pw_rigid"`, which is not true if it's nested under `"motion"`. Instead of dealing with both cases, I just switched it to reading the parameter from the params object.

The second is less important. I was looking for other places where the structure of `params["main"]` is assumed, and found this piece of code that converts lists to tuples. This should no longer be necessary now that `get_params_diffs` allows non-hashable parameter values (assuming that the comment about why it is there is accurate), so I removed it.

There are 2 failing tests, but I believe they are the same ones that have been failing consistently.