### PR TITLE
Fix motion correction and CNMF for 3D movies

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,7 @@
 channels:
   - conda-forge
 dependencies:
-  - caiman >= 1.9.10
+  - caiman >= 1.11.2
   - pandas >= 1.5.0
   - requests
   - click

--- a/environment_rtd.yml
+++ b/environment_rtd.yml
@@ -1,7 +1,7 @@
 channels:
   - conda-forge
 dependencies:
-  - caiman >= 1.9.10
+  - caiman >= 1.11.2
   - pandas >= 1.5.0
   - requests
   - click

--- a/mesmerize_core/algorithms/cnmf.py
+++ b/mesmerize_core/algorithms/cnmf.py
@@ -99,7 +99,7 @@ def run_algo(batch_path, uuid, data_path: str = None):
 
         cnm.save(str(output_path))
 
-        Cn = cm.local_correlations(images.transpose(1, 2, 0))
+        Cn = cm.local_correlations(images, swap_dim=False)
         Cn[np.isnan(Cn)] = 0
 
         corr_img_path = output_dir.joinpath(f"{uuid}_cn.npy").resolve()

--- a/mesmerize_core/algorithms/mcorr.py
+++ b/mesmerize_core/algorithms/mcorr.py
@@ -124,6 +124,8 @@ def run_algo(batch_path, uuid, data_path: str = None):
             x_shifts = mc.x_shifts_els
             y_shifts = mc.y_shifts_els
             shifts = [x_shifts, y_shifts]
+            if hasattr(mc, 'z_shifts_els'):
+                shifts += mc.z_shifts_els
             shift_path = output_dir.joinpath(f"{uuid}_shifts.npy")
             np.save(str(shift_path), shifts)
         else:

--- a/mesmerize_core/algorithms/mcorr.py
+++ b/mesmerize_core/algorithms/mcorr.py
@@ -10,9 +10,6 @@ from pathlib import Path, PurePosixPath
 import numpy as np
 from shutil import move as move_file
 import time
-import pkg_resources
-from packaging.version import Version
-
 
 # prevent circular import
 if __name__ in ["__main__", "__mp_main__"]:  # when running in subprocess
@@ -91,23 +88,15 @@ def run_algo(batch_path, uuid, data_path: str = None):
             )
             np.save(str(proj_paths[proj_type]), p_img)
 
-        is3D = len(dims) == 3
-        if is3D and Version(pkg_resources.get_distribution('caiman').version) < Version('1.11.2'):
-            # is3D parameter only (to be) added in version 1.11.2
-            print("Skipping correlation image of 3D movie (not supported)")
-            cn_path = None
-        else:
-            print("Computing correlation image")
-            kwargs = {'is3D': True} if is3D else {}
+        def run_correlation(remove_baseline=True) -> Path:
             Cns = local_correlations_movie_offline(
-                [str(mcorr_memmap_path)],
-                remove_baseline=True,
+                str(mcorr_memmap_path),
+                remove_baseline=remove_baseline,
                 window=1000,
                 stride=1000,
                 winSize_baseline=100,
                 quantil_min_baseline=10,
                 dview=dview,
-                **kwargs
             )
             Cn = Cns.max(axis=0)
             Cn[np.isnan(Cn)] = 0
@@ -115,6 +104,20 @@ def run_algo(batch_path, uuid, data_path: str = None):
             np.save(str(cn_path), Cn, allow_pickle=False)
             
             print("finished computing correlation image")
+            return cn_path
+
+        try:
+            print("Computing correlation image")
+            cn_path = run_correlation()
+
+        except ValueError as err:
+            # Test for error that occurs in movie.removeBL before bug was fixed
+            is3D = len(dims) == 3
+            if is3D and len(err.args) == 1 and err.args[0] == "axes don't match array":
+                print("Computing correlation on 3D image failed - trying without baseline (use caiman >= 1.11.2 to fix)")
+                cn_path = run_correlation(remove_baseline=False)
+            else:
+                raise
 
         # Compute shifts
         if opts.motion["pw_rigid"] == True:
@@ -132,8 +135,7 @@ def run_algo(batch_path, uuid, data_path: str = None):
         d = dict()
 
         # save paths as relative path strings with forward slashes
-        if cn_path is not None:
-            cn_path = str(PurePosixPath(cn_path.relative_to(output_dir.parent)))
+        cn_path = str(PurePosixPath(cn_path.relative_to(output_dir.parent)))
         mcorr_memmap_path = str(PurePosixPath(mcorr_memmap_path.relative_to(output_dir.parent)))
         shift_path = str(PurePosixPath(shift_path.relative_to(output_dir.parent)))
         for proj_type in proj_paths.keys():


### PR DESCRIPTION
The mcorr algorithm currently fails when run on a 3D movie during correlation image calculation. This is due to some code in caiman that could probably also be changed to get it to work (flatironinstitute/caiman#1363 does half of it), but this PR should fix mcorr in a way that is also compatible with existing caiman versions: 

- By passing the file in as a string rather than list, `load_file_chain` does not get called, which means `is3D` is not needed (otherwise this throws an error).
- I added a try/catch that should catch the specific bug fixed in flatironinstitute/caiman#1363 and tries again without baseline removal to avoid it.

This PR is dependent on #298 (to avoid an ugly merge) so I'm submitting it as a draft for now. Also, it would be good to add a test case for 3D motion correction (with test data and everything). But at least the current tests pass (except for the 2 that are always failing) so it doesn't break 2D mcorr.