### PR TITLE
Add async_local backend and allow using an existing dview for local and async_local backends

### DIFF
--- a/mesmerize_core/algorithms/_utils.py
+++ b/mesmerize_core/algorithms/_utils.py
@@ -1,0 +1,48 @@
+import caiman as cm
+from contextlib import contextmanager
+from ipyparallel import DirectView
+from multiprocessing.pool import Pool
+import os
+import psutil
+from typing import Union, Optional, Generator
+
+Cluster = Union[Pool, DirectView]
+
+def get_n_processes(dview: Optional[Cluster]) -> int:
+    """Infer number of processes in a multiprocessing or ipyparallel cluster"""
+    if isinstance(dview, Pool) and hasattr(dview, '_processes'):
+        return dview._processes
+    elif isinstance(dview, DirectView):
+        return len(dview)
+    else:
+        return 1
+
+
+@contextmanager
+def ensure_server(dview: Optional[Cluster]) -> Generator[tuple[Cluster, int], None, None]:
+    """
+    Context manager that passes through an existing 'dview' or
+    opens up a multiprocessing server if none is passed in.
+    If a server was opened, closes it upon exit.
+    Usage: `with ensure_server(dview) as (dview, n_processes):`
+    """
+    if dview is not None:
+        yield dview, get_n_processes(dview)
+    else:
+        # no cluster passed in, so open one
+        if "MESMERIZE_N_PROCESSES" in os.environ.keys():
+            try:
+                n_processes = int(os.environ["MESMERIZE_N_PROCESSES"])
+            except:
+                n_processes = psutil.cpu_count() - 1
+        else:
+            n_processes = psutil.cpu_count() - 1
+
+        # Start cluster for parallel processing
+        _, dview, n_processes = cm.cluster.setup_cluster(
+            backend="multiprocessing", n_processes=n_processes, single_thread=False
+        )
+        try:
+            yield dview, n_processes
+        finally:
+            cm.stop_server(dview=dview)

--- a/mesmerize_core/algorithms/cnmf.py
+++ b/mesmerize_core/algorithms/cnmf.py
@@ -1,4 +1,5 @@
 """Performs CNMF in a separate process"""
+import asyncio
 import click
 import caiman as cm
 from caiman.source_extraction.cnmf import cnmf as cnmf
@@ -20,7 +21,10 @@ else:  # when running with local backend
     from ..utils import IS_WINDOWS
 
 
-def run_algo(batch_path, uuid, data_path: str = None):
+def run_algo(batch_path, uuid, data_path: str = None, dview=None):
+    asyncio.run(run_algo_async(batch_path, uuid, data_path=data_path, dview=dview))
+
+async def run_algo_async(batch_path, uuid, data_path: str = None, dview=None):
     algo_start = time.time()
     set_parent_raw_data_path(data_path)
 
@@ -41,18 +45,23 @@ def run_algo(batch_path, uuid, data_path: str = None):
         f"Starting CNMF item:\n{item}\nWith params:{params}"
     )
 
-    # adapted from current demo notebook
-    if "MESMERIZE_N_PROCESSES" in os.environ.keys():
-        try:
-            n_processes = int(os.environ["MESMERIZE_N_PROCESSES"])
-        except:
-            n_processes = psutil.cpu_count() - 1
+    if 'multiprocessing' in str(type(dview)) and hasattr(dview, '_processes'):
+        n_processes = dview._processes
+    elif 'ipyparallel' in str(type(dview)):
+        n_processes = len(dview)
     else:
-        n_processes = psutil.cpu_count() - 1
-    # Start cluster for parallel processing
-    c, dview, n_processes = cm.cluster.setup_cluster(
-        backend="local", n_processes=n_processes, single_thread=False
-    )
+        # adapted from current demo notebook
+        if "MESMERIZE_N_PROCESSES" in os.environ.keys():
+            try:
+                n_processes = int(os.environ["MESMERIZE_N_PROCESSES"])
+            except:
+                n_processes = psutil.cpu_count() - 1
+        else:
+            n_processes = psutil.cpu_count() - 1
+        # Start cluster for parallel processing
+        c, dview, n_processes = cm.cluster.setup_cluster(
+            backend="multiprocessing", n_processes=n_processes, single_thread=False
+        )
 
     # merge cnmf and eval kwargs into one dict
     cnmf_params = CNMFParams(params_dict=params["main"])

--- a/mesmerize_core/algorithms/cnmf.py
+++ b/mesmerize_core/algorithms/cnmf.py
@@ -1,15 +1,12 @@
 """Performs CNMF in a separate process"""
-import asyncio
 import click
 import caiman as cm
 from caiman.source_extraction.cnmf import cnmf as cnmf
 from caiman.source_extraction.cnmf.params import CNMFParams
-import psutil
 import numpy as np
 import traceback
 from pathlib import Path, PurePosixPath
 from shutil import move as move_file
-import os
 import time
 
 # prevent circular import
@@ -24,9 +21,6 @@ else:  # when running with local backend
 
 
 def run_algo(batch_path, uuid, data_path: str = None, dview=None):
-    asyncio.run(run_algo_async(batch_path, uuid, data_path=data_path, dview=dview))
-
-async def run_algo_async(batch_path, uuid, data_path: str = None, dview=None):
     algo_start = time.time()
     set_parent_raw_data_path(data_path)
 

--- a/mesmerize_core/algorithms/cnmf.py
+++ b/mesmerize_core/algorithms/cnmf.py
@@ -16,9 +16,11 @@ import time
 if __name__ in ["__main__", "__mp_main__"]:  # when running in subprocess
     from mesmerize_core import set_parent_raw_data_path, load_batch
     from mesmerize_core.utils import IS_WINDOWS
+    from mesmerize_core.algorithms._utils import ensure_server
 else:  # when running with local backend
     from ..batch_utils import set_parent_raw_data_path, load_batch
     from ..utils import IS_WINDOWS
+    from ._utils import ensure_server
 
 
 def run_algo(batch_path, uuid, data_path: str = None, dview=None):
@@ -45,107 +47,84 @@ async def run_algo_async(batch_path, uuid, data_path: str = None, dview=None):
         f"Starting CNMF item:\n{item}\nWith params:{params}"
     )
 
-    if 'multiprocessing' in str(type(dview)) and hasattr(dview, '_processes'):
-        n_processes = dview._processes
-    elif 'ipyparallel' in str(type(dview)):
-        n_processes = len(dview)
-    else:
-        # adapted from current demo notebook
-        if "MESMERIZE_N_PROCESSES" in os.environ.keys():
-            try:
-                n_processes = int(os.environ["MESMERIZE_N_PROCESSES"])
-            except:
-                n_processes = psutil.cpu_count() - 1
-        else:
-            n_processes = psutil.cpu_count() - 1
-        # Start cluster for parallel processing
-        c, dview, n_processes = cm.cluster.setup_cluster(
-            backend="multiprocessing", n_processes=n_processes, single_thread=False
-        )
+    with ensure_server(dview) as (dview, n_processes):
 
-    # merge cnmf and eval kwargs into one dict
-    cnmf_params = CNMFParams(params_dict=params["main"])
-    # Run CNMF, denote boolean 'success' if CNMF completes w/out error
-    try:
-        fname_new = cm.save_memmap(
-            [input_movie_path], base_name=f"{uuid}_cnmf-memmap_", order="C", dview=dview
-        )
-
-        print("making memmap")
-
-        Yr, dims, T = cm.load_memmap(fname_new)
-        images = np.reshape(Yr.T, [T] + list(dims), order="F")
-
-        proj_paths = dict()
-        for proj_type in ["mean", "std", "max"]:
-            p_img = getattr(np, f"nan{proj_type}")(images, axis=0)
-            proj_paths[proj_type] = output_dir.joinpath(
-                f"{uuid}_{proj_type}_projection.npy"
+        # merge cnmf and eval kwargs into one dict
+        cnmf_params = CNMFParams(params_dict=params["main"])
+        # Run CNMF, denote boolean 'success' if CNMF completes w/out error
+        try:
+            fname_new = cm.save_memmap(
+                [input_movie_path], base_name=f"{uuid}_cnmf-memmap_", order="C", dview=dview
             )
-            np.save(str(proj_paths[proj_type]), p_img)
 
-        # in fname new load in memmap order C
-        cm.stop_server(dview=dview)
-        c, dview, n_processes = cm.cluster.setup_cluster(
-            backend="local", n_processes=None, single_thread=False
-        )
+            print("making memmap")
 
-        print("performing CNMF")
-        cnm = cnmf.CNMF(n_processes, params=cnmf_params, dview=dview)
+            Yr, dims, T = cm.load_memmap(fname_new)
 
-        print("fitting images")
-        cnm = cnm.fit(images)
-        #
-        if "refit" in params.keys():
-            if params["refit"] is True:
-                print("refitting")
-                cnm = cnm.refit(images, dview=dview)
+            images = np.reshape(Yr.T, [T] + list(dims), order="F")
 
-        print("performing eval")
-        cnm.estimates.evaluate_components(images, cnm.params, dview=dview)
+            proj_paths = dict()
+            for proj_type in ["mean", "std", "max"]:
+                p_img = getattr(np, f"nan{proj_type}")(images, axis=0)
+                proj_paths[proj_type] = output_dir.joinpath(
+                    f"{uuid}_{proj_type}_projection.npy"
+                )
+                np.save(str(proj_paths[proj_type]), p_img)
 
-        output_path = output_dir.joinpath(f"{uuid}.hdf5").resolve()
+            print("performing CNMF")
+            cnm = cnmf.CNMF(n_processes, params=cnmf_params, dview=dview)
 
-        cnm.save(str(output_path))
+            print("fitting images")
+            cnm = cnm.fit(images)
+            #
+            if "refit" in params.keys():
+                if params["refit"] is True:
+                    print("refitting")
+                    cnm = cnm.refit(images, dview=dview)
 
-        Cn = cm.local_correlations(images.transpose(1, 2, 0))
-        Cn[np.isnan(Cn)] = 0
+            print("performing eval")
+            cnm.estimates.evaluate_components(images, cnm.params, dview=dview)
 
-        corr_img_path = output_dir.joinpath(f"{uuid}_cn.npy").resolve()
-        np.save(str(corr_img_path), Cn, allow_pickle=False)
+            output_path = output_dir.joinpath(f"{uuid}.hdf5").resolve()
 
-        # output dict for dataframe row (pd.Series)
-        d = dict()
+            cnm.save(str(output_path))
 
-        cnmf_memmap_path = output_dir.joinpath(Path(fname_new).name)
-        if IS_WINDOWS:
-            Yr._mmap.close()  # accessing private attr but windows is annoying otherwise
-        move_file(fname_new, cnmf_memmap_path)
+            Cn = cm.local_correlations(images.transpose(1, 2, 0))
+            Cn[np.isnan(Cn)] = 0
 
-        # save paths as relative path strings with forward slashes
-        cnmf_hdf5_path = str(PurePosixPath(output_path.relative_to(output_dir.parent)))
-        cnmf_memmap_path = str(PurePosixPath(cnmf_memmap_path.relative_to(output_dir.parent)))
-        corr_img_path = str(PurePosixPath(corr_img_path.relative_to(output_dir.parent)))
-        for proj_type in proj_paths.keys():
-            d[f"{proj_type}-projection-path"] = str(PurePosixPath(proj_paths[proj_type].relative_to(
-                output_dir.parent
-            )))
+            corr_img_path = output_dir.joinpath(f"{uuid}_cn.npy").resolve()
+            np.save(str(corr_img_path), Cn, allow_pickle=False)
 
-        d.update(
-            {
-                "cnmf-hdf5-path": cnmf_hdf5_path,
-                "cnmf-memmap-path": cnmf_memmap_path,
-                "corr-img-path": corr_img_path,
-                "success": True,
-                "traceback": None,
-            }
-        )
+            # output dict for dataframe row (pd.Series)
+            d = dict()
 
-    except:
-        d = {"success": False, "traceback": traceback.format_exc()}
+            cnmf_memmap_path = output_dir.joinpath(Path(fname_new).name)
+            if IS_WINDOWS:
+                Yr._mmap.close()  # accessing private attr but windows is annoying otherwise
+            move_file(fname_new, cnmf_memmap_path)
 
-    cm.stop_server(dview=dview)
-    
+            # save paths as relative path strings with forward slashes
+            cnmf_hdf5_path = str(PurePosixPath(output_path.relative_to(output_dir.parent)))
+            cnmf_memmap_path = str(PurePosixPath(cnmf_memmap_path.relative_to(output_dir.parent)))
+            corr_img_path = str(PurePosixPath(corr_img_path.relative_to(output_dir.parent)))
+            for proj_type in proj_paths.keys():
+                d[f"{proj_type}-projection-path"] = str(PurePosixPath(proj_paths[proj_type].relative_to(
+                    output_dir.parent
+                )))
+
+            d.update(
+                {
+                    "cnmf-hdf5-path": cnmf_hdf5_path,
+                    "cnmf-memmap-path": cnmf_memmap_path,
+                    "corr-img-path": corr_img_path,
+                    "success": True,
+                    "traceback": None,
+                }
+            )
+
+        except:
+            d = {"success": False, "traceback": traceback.format_exc()}
+
     runtime = round(time.time() - algo_start, 2)
     df.caiman.update_item_with_results(uuid, d, runtime)
 

--- a/mesmerize_core/algorithms/cnmfe.py
+++ b/mesmerize_core/algorithms/cnmfe.py
@@ -1,14 +1,11 @@
-import asyncio
 import click
 import numpy as np
 import caiman as cm
 from caiman.source_extraction.cnmf import cnmf as cnmf
 from caiman.source_extraction.cnmf.params import CNMFParams
-import psutil
 import traceback
 from pathlib import Path, PurePosixPath
 from shutil import move as move_file
-import os
 import time
 
 if __name__ in ["__main__", "__mp_main__"]:  # when running in subprocess
@@ -22,9 +19,6 @@ else:  # when running with local backend
 
 
 def run_algo(batch_path, uuid, data_path: str = None, dview=None):
-    asyncio.run(run_algo_async(batch_path, uuid, data_path=data_path, dview=dview))
-
-async def run_algo_async(batch_path, uuid, data_path: str = None, dview=None):
     algo_start = time.time()
     set_parent_raw_data_path(data_path)
 

--- a/mesmerize_core/algorithms/cnmfe.py
+++ b/mesmerize_core/algorithms/cnmfe.py
@@ -14,9 +14,11 @@ import time
 if __name__ in ["__main__", "__mp_main__"]:  # when running in subprocess
     from mesmerize_core import set_parent_raw_data_path, load_batch
     from mesmerize_core.utils import IS_WINDOWS
+    from mesmerize_core.algorithms._utils import ensure_server
 else:  # when running with local backend
     from ..batch_utils import set_parent_raw_data_path, load_batch
     from ..utils import IS_WINDOWS
+    from ._utils import ensure_server
 
 
 def run_algo(batch_path, uuid, data_path: str = None, dview=None):
@@ -39,96 +41,77 @@ async def run_algo_async(batch_path, uuid, data_path: str = None, dview=None):
     params = item["params"]
     print("cnmfe params:", params)
 
-    if 'multiprocessing' in str(type(dview)) and hasattr(dview, '_processes'):
-        n_processes = dview._processes
-    elif 'ipyparallel' in str(type(dview)):
-        n_processes = len(dview)
-    else:
-        # adapted from current demo notebook
-        if "MESMERIZE_N_PROCESSES" in os.environ.keys():
-            try:
-                n_processes = int(os.environ["MESMERIZE_N_PROCESSES"])
-            except:
-                n_processes = psutil.cpu_count() - 1
-        else:
-            n_processes = psutil.cpu_count() - 1
-        # Start cluster for parallel processing
-        c, dview, n_processes = cm.cluster.setup_cluster(
-            backend="multiprocessing", n_processes=n_processes, single_thread=False
-        )
-
-    try:
-        fname_new = cm.save_memmap(
-            [input_movie_path], base_name=f"{uuid}_cnmf-memmap_", order="C", dview=dview
-        )
-
-        print("making memmap")
-        Yr, dims, T = cm.load_memmap(fname_new)
-        images = np.reshape(Yr.T, [T] + list(dims), order="F")
-
-        # TODO: if projections already exist from mcorr we don't
-        #  need to waste compute time re-computing them here
-        proj_paths = dict()
-        for proj_type in ["mean", "std", "max"]:
-            p_img = getattr(np, f"nan{proj_type}")(images, axis=0)
-            proj_paths[proj_type] = output_dir.joinpath(
-                f"{uuid}_{proj_type}_projection.npy"
-            )
-            np.save(str(proj_paths[proj_type]), p_img)
-
-        d = dict()  # for output
-
-        # force the CNMFE params
-        cnmfe_params_dict = {
-            "method_init": "corr_pnr",
-            "n_processes": n_processes,
-            "only_init": True,  # for 1p
-            "center_psf": True,  # for 1p
-            "normalize_init": False,  # for 1p
-        }
-
-        params_dict = {**cnmfe_params_dict, **params["main"]}
-
-        cnmfe_params_dict = CNMFParams(params_dict=params_dict)
-        cnm = cnmf.CNMF(
-            n_processes=n_processes, dview=dview, params=cnmfe_params_dict
-        )
-        print("Performing CNMFE")
-        cnm = cnm.fit(images)
-        print("evaluating components")
-        cnm.estimates.evaluate_components(images, cnm.params, dview=dview)
-
-        cnmf_hdf5_path = output_dir.joinpath(f"{uuid}.hdf5").resolve()
-        cnm.save(str(cnmf_hdf5_path))
-
-        # save output paths to outputs dict
-        d["cnmf-hdf5-path"] = cnmf_hdf5_path.relative_to(output_dir.parent)
-
-        for proj_type in proj_paths.keys():
-            d[f"{proj_type}-projection-path"] = proj_paths[proj_type].relative_to(
-                output_dir.parent
+    with ensure_server(dview) as (dview, n_processes):
+        try:
+            fname_new = cm.save_memmap(
+                [input_movie_path], base_name=f"{uuid}_cnmf-memmap_", order="C", dview=dview
             )
 
-        cnmf_memmap_path = output_dir.joinpath(Path(fname_new).name)
-        if IS_WINDOWS:
-            Yr._mmap.close()  # accessing private attr but windows is annoying otherwise
-        move_file(fname_new, cnmf_memmap_path)
+            print("making memmap")
+            Yr, dims, T = cm.load_memmap(fname_new)
+            images = np.reshape(Yr.T, [T] + list(dims), order="F")
 
-        # save path as relative path strings with forward slashes
-        cnmfe_memmap_path = str(PurePosixPath(cnmf_memmap_path.relative_to(output_dir.parent)))
+            # TODO: if projections already exist from mcorr we don't
+            #  need to waste compute time re-computing them here
+            proj_paths = dict()
+            for proj_type in ["mean", "std", "max"]:
+                p_img = getattr(np, f"nan{proj_type}")(images, axis=0)
+                proj_paths[proj_type] = output_dir.joinpath(
+                    f"{uuid}_{proj_type}_projection.npy"
+                )
+                np.save(str(proj_paths[proj_type]), p_img)
 
-        d.update(
-            {
-                "cnmf-memmap-path": cnmfe_memmap_path,
-                "success": True,
-                "traceback": None,
+            d = dict()  # for output
+
+            # force the CNMFE params
+            cnmfe_params_dict = {
+                "method_init": "corr_pnr",
+                "n_processes": n_processes,
+                "only_init": True,  # for 1p
+                "center_psf": True,  # for 1p
+                "normalize_init": False,  # for 1p
             }
-        )
 
-    except:
-        d = {"success": False, "traceback": traceback.format_exc()}
+            params_dict = {**cnmfe_params_dict, **params["main"]}
 
-    cm.stop_server(dview=dview)
+            cnmfe_params_dict = CNMFParams(params_dict=params_dict)
+            cnm = cnmf.CNMF(
+                n_processes=n_processes, dview=dview, params=cnmfe_params_dict
+            )
+            print("Performing CNMFE")
+            cnm = cnm.fit(images)
+            print("evaluating components")
+            cnm.estimates.evaluate_components(images, cnm.params, dview=dview)
+
+            cnmf_hdf5_path = output_dir.joinpath(f"{uuid}.hdf5").resolve()
+            cnm.save(str(cnmf_hdf5_path))
+
+            # save output paths to outputs dict
+            d["cnmf-hdf5-path"] = cnmf_hdf5_path.relative_to(output_dir.parent)
+
+            for proj_type in proj_paths.keys():
+                d[f"{proj_type}-projection-path"] = proj_paths[proj_type].relative_to(
+                    output_dir.parent
+                )
+
+            cnmf_memmap_path = output_dir.joinpath(Path(fname_new).name)
+            if IS_WINDOWS:
+                Yr._mmap.close()  # accessing private attr but windows is annoying otherwise
+            move_file(fname_new, cnmf_memmap_path)
+
+            # save path as relative path strings with forward slashes
+            cnmfe_memmap_path = str(PurePosixPath(cnmf_memmap_path.relative_to(output_dir.parent)))
+
+            d.update(
+                {
+                    "cnmf-memmap-path": cnmfe_memmap_path,
+                    "success": True,
+                    "traceback": None,
+                }
+            )
+
+        except:
+            d = {"success": False, "traceback": traceback.format_exc()}
 
     runtime = round(time.time() - algo_start, 2)
     df.caiman.update_item_with_results(uuid, d, runtime)

--- a/mesmerize_core/algorithms/mcorr.py
+++ b/mesmerize_core/algorithms/mcorr.py
@@ -1,11 +1,9 @@
 import traceback
-import asyncio
 import click
 import caiman as cm
 from caiman.source_extraction.cnmf.params import CNMFParams
 from caiman.motion_correction import MotionCorrect
 from caiman.summary_images import local_correlations_movie_offline
-import psutil
 import os
 from pathlib import Path, PurePosixPath
 import numpy as np
@@ -22,9 +20,6 @@ else:  # when running with local backend
 
 
 def run_algo(batch_path, uuid, data_path: str = None, dview=None):
-    asyncio.run(run_algo_async(batch_path, uuid, data_path=data_path, dview=dview))
-
-async def run_algo_async(batch_path, uuid, data_path: str = None, dview=None):
     algo_start = time.time()
     set_parent_raw_data_path(data_path)
 

--- a/mesmerize_core/algorithms/mcorr.py
+++ b/mesmerize_core/algorithms/mcorr.py
@@ -15,8 +15,10 @@ import time
 # prevent circular import
 if __name__ in ["__main__", "__mp_main__"]:  # when running in subprocess
     from mesmerize_core import set_parent_raw_data_path, load_batch
+    from mesmerize_core.algorithms._utils import ensure_server
 else:  # when running with local backend
     from ..batch_utils import set_parent_raw_data_path, load_batch
+    from ._utils import ensure_server
 
 
 def run_algo(batch_path, uuid, data_path: str = None, dview=None):
@@ -43,117 +45,97 @@ async def run_algo_async(batch_path, uuid, data_path: str = None, dview=None):
 
     params = item["params"]
 
-    # adapted from current demo notebook
-    if 'multiprocessing' in str(type(dview)) and hasattr(dview, '_processes'):
-        n_processes = dview._processes
-    elif 'ipyparallel' in str(type(dview)):
-        n_processes = len(dview)
-    else:
-        # adapted from current demo notebook
-        if "MESMERIZE_N_PROCESSES" in os.environ.keys():
-            try:
-                n_processes = int(os.environ["MESMERIZE_N_PROCESSES"])
-            except:
-                n_processes = psutil.cpu_count() - 1
-        else:
-            n_processes = psutil.cpu_count() - 1
-        # Start cluster for parallel processing
-        c, dview, n_processes = cm.cluster.setup_cluster(
-            backend="multiprocessing", n_processes=n_processes, single_thread=False
-        )
+    with ensure_server(dview) as (dview, n_processes):
+        print("starting mc")
 
-    print("starting mc")
+        rel_params = dict(params["main"])
+        opts = CNMFParams(params_dict=rel_params)
+        # Run MC, denote boolean 'success' if MC completes w/out error
+        try:
+            # Run MC
+            fnames = [input_movie_path]
+            mc = MotionCorrect(fnames, dview=dview, **opts.get_group("motion"))
+            mc.motion_correct(save_movie=True)
 
-    rel_params = dict(params["main"])
-    opts = CNMFParams(params_dict=rel_params)
-    # Run MC, denote boolean 'success' if MC completes w/out error
-    try:
-        # Run MC
-        fnames = [input_movie_path]
-        mc = MotionCorrect(fnames, dview=dview, **opts.get_group("motion"))
-        mc.motion_correct(save_movie=True)
+            # find path to mmap file
+            memmap_output_path_temp = df.paths.resolve(mc.mmap_file[0])
 
-        # find path to mmap file
-        memmap_output_path_temp = df.paths.resolve(mc.mmap_file[0])
-
-        # filename to move the output back to data dir
-        mcorr_memmap_path = output_dir.joinpath(
-            f"{uuid}-{memmap_output_path_temp.name}"
-        )
-
-        # move the output file
-        move_file(memmap_output_path_temp, mcorr_memmap_path)
-
-        print("mc finished successfully!")
-
-        print("computing projections")
-        Yr, dims, T = cm.load_memmap(str(mcorr_memmap_path))
-        images = np.reshape(Yr.T, [T] + list(dims), order="F")
-
-        proj_paths = dict()
-        for proj_type in ["mean", "std", "max"]:
-            p_img = getattr(np, f"nan{proj_type}")(images, axis=0)
-            proj_paths[proj_type] = output_dir.joinpath(
-                f"{uuid}_{proj_type}_projection.npy"
+            # filename to move the output back to data dir
+            mcorr_memmap_path = output_dir.joinpath(
+                f"{uuid}-{memmap_output_path_temp.name}"
             )
-            np.save(str(proj_paths[proj_type]), p_img)
 
-        print("Computing correlation image")
-        Cns = local_correlations_movie_offline(
-            [str(mcorr_memmap_path)],
-            remove_baseline=True,
-            window=1000,
-            stride=1000,
-            winSize_baseline=100,
-            quantil_min_baseline=10,
-            dview=dview,
-        )
-        Cn = Cns.max(axis=0)
-        Cn[np.isnan(Cn)] = 0
-        cn_path = output_dir.joinpath(f"{uuid}_cn.npy")
-        np.save(str(cn_path), Cn, allow_pickle=False)
+            # move the output file
+            move_file(memmap_output_path_temp, mcorr_memmap_path)
 
-        # output dict for pandas series for dataframe row
-        d = dict()
+            print("mc finished successfully!")
 
-        print("finished computing correlation image")
+            print("computing projections")
+            Yr, dims, T = cm.load_memmap(str(mcorr_memmap_path))
+            images = np.reshape(Yr.T, [T] + list(dims), order="F")
 
-        # Compute shifts
-        if opts.motion["pw_rigid"] == True:
-            x_shifts = mc.x_shifts_els
-            y_shifts = mc.y_shifts_els
-            shifts = [x_shifts, y_shifts]
-            shift_path = output_dir.joinpath(f"{uuid}_shifts.npy")
-            np.save(str(shift_path), shifts)
-        else:
-            shifts = mc.shifts_rig
-            shift_path = output_dir.joinpath(f"{uuid}_shifts.npy")
-            np.save(str(shift_path), shifts)
+            proj_paths = dict()
+            for proj_type in ["mean", "std", "max"]:
+                p_img = getattr(np, f"nan{proj_type}")(images, axis=0)
+                proj_paths[proj_type] = output_dir.joinpath(
+                    f"{uuid}_{proj_type}_projection.npy"
+                )
+                np.save(str(proj_paths[proj_type]), p_img)
 
-        # save paths as relative path strings with forward slashes
-        cn_path = str(PurePosixPath(cn_path.relative_to(output_dir.parent)))
-        mcorr_memmap_path = str(PurePosixPath(mcorr_memmap_path.relative_to(output_dir.parent)))
-        shift_path = str(PurePosixPath(shift_path.relative_to(output_dir.parent)))
-        for proj_type in proj_paths.keys():
-            d[f"{proj_type}-projection-path"] = str(PurePosixPath(proj_paths[proj_type].relative_to(
-                output_dir.parent
-            )))
+            print("Computing correlation image")
+            Cns = local_correlations_movie_offline(
+                [str(mcorr_memmap_path)],
+                remove_baseline=True,
+                window=1000,
+                stride=1000,
+                winSize_baseline=100,
+                quantil_min_baseline=10,
+                dview=dview,
+            )
+            Cn = Cns.max(axis=0)
+            Cn[np.isnan(Cn)] = 0
+            cn_path = output_dir.joinpath(f"{uuid}_cn.npy")
+            np.save(str(cn_path), Cn, allow_pickle=False)
 
-        d.update(
-            {
-                "mcorr-output-path": mcorr_memmap_path,
-                "corr-img-path": cn_path,
-                "shifts": shift_path,
-                "success": True,
-                "traceback": None,
-            }
-        )
+            # output dict for pandas series for dataframe row
+            d = dict()
 
-    except:
-        d = {"success": False, "traceback": traceback.format_exc()}
-        print("mc failed, stored traceback in output")
+            print("finished computing correlation image")
 
-    cm.stop_server(dview=dview)
+            # Compute shifts
+            if opts.motion["pw_rigid"] == True:
+                x_shifts = mc.x_shifts_els
+                y_shifts = mc.y_shifts_els
+                shifts = [x_shifts, y_shifts]
+                shift_path = output_dir.joinpath(f"{uuid}_shifts.npy")
+                np.save(str(shift_path), shifts)
+            else:
+                shifts = mc.shifts_rig
+                shift_path = output_dir.joinpath(f"{uuid}_shifts.npy")
+                np.save(str(shift_path), shifts)
+
+            # save paths as relative path strings with forward slashes
+            cn_path = str(PurePosixPath(cn_path.relative_to(output_dir.parent)))
+            mcorr_memmap_path = str(PurePosixPath(mcorr_memmap_path.relative_to(output_dir.parent)))
+            shift_path = str(PurePosixPath(shift_path.relative_to(output_dir.parent)))
+            for proj_type in proj_paths.keys():
+                d[f"{proj_type}-projection-path"] = str(PurePosixPath(proj_paths[proj_type].relative_to(
+                    output_dir.parent
+                )))
+
+            d.update(
+                {
+                    "mcorr-output-path": mcorr_memmap_path,
+                    "corr-img-path": cn_path,
+                    "shifts": shift_path,
+                    "success": True,
+                    "traceback": None,
+                }
+            )
+
+        except:
+            d = {"success": False, "traceback": traceback.format_exc()}
+            print("mc failed, stored traceback in output")
 
     runtime = round(time.time() - algo_start, 2)
     df.caiman.update_item_with_results(uuid, d, runtime)

--- a/mesmerize_core/batch_utils.py
+++ b/mesmerize_core/batch_utils.py
@@ -13,8 +13,9 @@ PARENT_DATA_PATH: Path = None
 COMPUTE_BACKEND_SUBPROCESS = "subprocess"  #: subprocess backend
 COMPUTE_BACKEND_SLURM = "slurm"  #: SLURM backend
 COMPUTE_BACKEND_LOCAL = "local"
+COMPUTE_BACKEND_ASYNC = "local_async"
 
-COMPUTE_BACKENDS = [COMPUTE_BACKEND_SUBPROCESS, COMPUTE_BACKEND_SLURM, COMPUTE_BACKEND_LOCAL]
+COMPUTE_BACKENDS = [COMPUTE_BACKEND_SUBPROCESS, COMPUTE_BACKEND_SLURM, COMPUTE_BACKEND_LOCAL, COMPUTE_BACKEND_ASYNC]
 
 DATAFRAME_COLUMNS = ["algo", "item_name", "input_movie_path", "params", "outputs", "added_time", "ran_time", "algo_duration", "comments", "uuid"]
 

--- a/mesmerize_core/caiman_extensions/common.py
+++ b/mesmerize_core/caiman_extensions/common.py
@@ -10,6 +10,7 @@ from datetime import datetime
 import time
 from copy import deepcopy
 import shlex
+import asyncio
 
 import numpy as np
 import pandas as pd
@@ -21,6 +22,7 @@ from ..batch_utils import (
     COMPUTE_BACKENDS,
     COMPUTE_BACKEND_SUBPROCESS,
     COMPUTE_BACKEND_LOCAL,
+    COMPUTE_BACKEND_ASYNC,
     get_parent_raw_data_path,
     load_batch,
 )
@@ -480,15 +482,27 @@ class CaimanSeriesExtensions:
             batch_path: Path,
             uuid: UUID,
             data_path: Union[Path, None],
-    ):
+            dview=None
+    ) -> DummyProcess:
+        coroutine = self._run_local_async(algo, batch_path, uuid, data_path, dview)
+        asyncio.run(coroutine)
+        return DummyProcess()
+
+    def _run_local_async(
+            self,
+            algo: str,
+            batch_path: Path,
+            uuid: UUID,
+            data_path: Union[Path, None],
+            dview=None
+    ) -> Coroutine:
         algo_module = getattr(algorithms, algo)
-        algo_module.run_algo(
+        return algo_module.run_algo_async(
             batch_path=str(batch_path),
             uuid=str(uuid),
-            data_path=str(data_path)
+            data_path=str(data_path),
+            dview=dview
         )
-
-        return DummyProcess()
 
     def _run_subprocess(
         self,
@@ -599,13 +613,14 @@ class CaimanSeriesExtensions:
 
         batch_path = self._series.paths.get_batch_path()
 
-        if backend == COMPUTE_BACKEND_LOCAL:
-            print(f"Running {self._series.uuid} with local backend")
-            return self._run_local(
+        if backend in [COMPUTE_BACKEND_LOCAL, COMPUTE_BACKEND_ASYNC]:
+            print(f"Running {self._series.uuid} with {backend} backend")
+            return getattr(self, f"_run_{backend}")(
                 algo=self._series["algo"],
                 batch_path=batch_path,
                 uuid=self._series["uuid"],
                 data_path=get_parent_raw_data_path(),
+                dview=kwargs.get("dview")
             )
 
         # Create the runfile in the batch dir using this Series' UUID as the filename

--- a/mesmerize_core/caiman_extensions/common.py
+++ b/mesmerize_core/caiman_extensions/common.py
@@ -10,7 +10,7 @@ from datetime import datetime
 import time
 from copy import deepcopy
 import shlex
-import asyncio
+from concurrent.futures import ThreadPoolExecutor, Future
 
 import numpy as np
 import pandas as pd
@@ -460,10 +460,24 @@ class CaimanDataFrameExtensions:
                 return r["uuid"]
 
 
-class DummyProcess:
+class Waitable(Protocol):
+    """An object that we can call "wait" on"""
+    def wait(self) -> None: ...
+
+
+class DummyProcess(Waitable):
     """Dummy process for local backend"""
-    def wait(self):
+    def wait(self) -> None:
         pass
+
+
+class WaitableFuture(Waitable):
+    """Adaptor for future returned from Executor.submit"""
+    def __init__(self, future: Future[None]):
+        self.future = future
+    
+    def wait(self) -> None:
+        return self.future.result()
 
 
 @pd.api.extensions.register_series_accessor("caiman")
@@ -474,7 +488,7 @@ class CaimanSeriesExtensions:
 
     def __init__(self, s: pd.Series):
         self._series = s
-        self.process: Popen = None
+        self.process: Optional[Waitable] = None
 
     def _run_local(
             self,
@@ -484,9 +498,15 @@ class CaimanSeriesExtensions:
             data_path: Union[Path, None],
             dview=None
     ) -> DummyProcess:
-        coroutine = self._run_local_async(algo, batch_path, uuid, data_path, dview)
-        asyncio.run(coroutine)
-        return DummyProcess()
+        algo_module = getattr(algorithms, algo)
+        algo_module.run_algo(
+            batch_path=str(batch_path),
+            uuid=str(uuid),
+            data_path=str(data_path),
+            dview=dview
+        )
+        self.process = DummyProcess()
+        return self.process
 
     def _run_local_async(
             self,
@@ -495,14 +515,18 @@ class CaimanSeriesExtensions:
             uuid: UUID,
             data_path: Union[Path, None],
             dview=None
-    ) -> Coroutine:
+    ) -> WaitableFuture:
         algo_module = getattr(algorithms, algo)
-        return algo_module.run_algo_async(
-            batch_path=str(batch_path),
-            uuid=str(uuid),
-            data_path=str(data_path),
-            dview=dview
-        )
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            future = executor.submit(
+                algo_module.run_algo,
+                batch_path=str(batch_path),
+                uuid=str(uuid),
+                data_path=str(data_path),
+                dview=dview
+                )
+            self.process = WaitableFuture(future)
+            return self.process
 
     def _run_subprocess(
         self,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,5 +1,4 @@
 import os
-
 import numpy as np
 from caiman.utils.utils import load_dict_from_hdf5
 from caiman.source_extraction.cnmf import cnmf
@@ -12,8 +11,14 @@ from mesmerize_core import (
     CaimanSeriesExtensions,
     set_parent_raw_data_path,
 )
-from mesmerize_core.batch_utils import DATAFRAME_COLUMNS, COMPUTE_BACKEND_SUBPROCESS, get_full_raw_data_path
+from mesmerize_core.batch_utils import (
+    DATAFRAME_COLUMNS,
+    COMPUTE_BACKEND_SUBPROCESS,
+    COMPUTE_BACKEND_LOCAL,
+    COMPUTE_BACKEND_ASYNC,
+    get_full_raw_data_path)
 from mesmerize_core.utils import IS_WINDOWS
+from mesmerize_core.algorithms._utils import ensure_server
 from uuid import uuid4
 from typing import *
 import pytest
@@ -29,6 +34,8 @@ from mesmerize_core.caiman_extensions import cnmf
 import time
 import tifffile
 from copy import deepcopy
+
+pytest_plugins = ('pytest_asyncio',)
 
 tmp_dir = Path(os.path.dirname(os.path.abspath(__file__)), "tmp")
 vid_dir = Path(os.path.dirname(os.path.abspath(__file__)), "videos")
@@ -1254,3 +1261,48 @@ def test_cache():
     output2 = df.iloc[1].cnmf.get_output(return_copy=False)
     assert(hex(id(output)) == hex(id(output2)))
     assert(hex(id(cnmf.cnmf_cache.get_cache().iloc[-1]["return_val"])) == hex(id(output)))
+
+
+def test_backends():
+    """test subprocess, local, and async_local backend"""
+    set_parent_raw_data_path(vid_dir)
+    algo = "mcorr"
+    df, batch_path = _create_tmp_batch()
+    input_movie_path = get_datafile(algo)
+
+    # make small version of movie for quick testing
+    movie = tifffile.imread(input_movie_path)
+    small_movie_path = input_movie_path.parent.joinpath("small_movie.tif")
+    tifffile.imwrite(small_movie_path, movie[:1001])
+    print(input_movie_path)
+
+    # put backends that can run in the background first to save time
+    backends = [COMPUTE_BACKEND_SUBPROCESS, COMPUTE_BACKEND_ASYNC, COMPUTE_BACKEND_LOCAL]
+    for backend in backends:
+        df.caiman.add_item(
+            algo="mcorr",
+            item_name=f"test-{backend}",
+            input_movie_path=small_movie_path,
+            params=test_params["mcorr"],
+        )
+
+    # run using each backend
+    procs = []
+    with ensure_server(None) as (dview, _):
+        for backend, (_, item) in zip(backends, df.iterrows()):
+            procs.append(item.caiman.run(backend=backend, dview=dview, wait=False))
+    
+    # wait for all to finish
+    for proc in procs:
+        proc.wait()
+
+    # compare results
+    df = load_batch(batch_path)
+    for i, item in df.iterrows():
+        output = item.mcorr.get_output()
+
+        if i == 0:
+            # save to compare to other results
+            first_output = output
+        else:
+            numpy.testing.assert_array_equal(output, first_output)


### PR DESCRIPTION
This is a feature I added for myself, and I think it may be useful for others so I'm offering it here.

**Problem**: mesmerize is currently inflexible with regard to how the parallel processing is set up. Running an item always opens a new multiprocessing pool; you can control the number of processes through the MESMERIZE_N_PROCESSES environment variable, but that's it. I wanted to have the ability to a) pass in an existing cluster to multiple runs, to save overhead, and/or b) use a different type of cluster (e.g. an ipyparallel cluster spanning multiple nodes, or even a [load-balanced view](https://ipyparallel.readthedocs.io/en/latest/tutorial/task.html)).

**Solution**: Passing a pool or dview into the run function clearly won't work with a subprocess, so the subprocess and slurm backends are out. The local backend calls the function directly, but it has the disadvantage that it blocks, so only one gridsearch run can be done at a time. However, we can get around that by spawning a thread (again, not a subprocess; the cluster objects can't be pickled).

I added a new backend called "local_async," which just launches a local run in a thread using the `concurrent.futures` module from the standard library. I also made it possible to pass a dview into both the local and local_async backends. I factored out some boilerplate from the 3 algorithm files into a `_utils.py` file that launches a new multiprocessing pool if no dview was passed in (and closes it when finished), and otherwise just forwards what was passed in. 

Finally, I added a test that compares results from the 3 non-SLURM backends.