### PR TITLE
Make get_shifts return value more useful; add test for shifts

### DIFF
--- a/mesmerize_core/caiman_extensions/mcorr.py
+++ b/mesmerize_core/caiman_extensions/mcorr.py
@@ -91,7 +91,7 @@ class MCorrExtensions:
         return mc_movie
 
     @validate("mcorr")
-    def get_shifts(self, pw_rigid) -> tuple[list[np.ndarray], list[np.ndarray]]:
+    def get_shifts(self, pw_rigid) -> list[np.ndarray]:
         """
         Gets file path to shifts array (.npy file) for item, processes shifts array
         into a list of x and y shifts based on whether rigid or nonrigid

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -44,7 +44,7 @@ os.makedirs(ground_truths_dir, exist_ok=True)
 
 def _download_ground_truths():
     print(f"Downloading ground truths")
-    url = f"https://zenodo.org/record/6828096/files/ground_truths.zip"
+    url = f"https://zenodo.org/record/13732996/files/ground_truths.zip"
 
     # basically from https://stackoverflow.com/questions/37573483/progress-bar-while-download-file-over-http-with-requests/37573701
     response = requests.get(url, stream=True)
@@ -252,6 +252,15 @@ def test_mcorr():
     )
     )
 
+    # test to check shifts output path
+    assert (
+        batch_dir.joinpath(df.iloc[-1]["outputs"]["shifts"])
+        == df.paths.resolve(df.iloc[-1]["outputs"]["shifts"])
+        == batch_dir.joinpath(
+            str(df.iloc[-1]["uuid"]), f'{df.iloc[-1]["uuid"]}_shifts.npy'
+        )
+    )
+
     # test to check mean-projection output path
     assert (
             batch_dir.joinpath(df.iloc[-1]["outputs"]["mean-projection-path"])
@@ -302,6 +311,15 @@ def test_mcorr():
         ground_truths_dir.joinpath("mcorr", "mcorr_output.npy")
     )
     numpy.testing.assert_array_equal(mcorr_output, mcorr_output_actual)
+
+
+    # test to check mcorr get_shifts()
+    mcorr_shifts = df.iloc[-1].mcorr.get_shifts(pw_rigid=test_params[algo]["main"]["pw_rigid"])
+    mcorr_shifts_actual = numpy.load(
+        ground_truths_dir.joinpath("mcorr", "mcorr_shifts.npy")
+    )
+    numpy.testing.assert_array_equal(mcorr_shifts, mcorr_shifts_actual)
+
 
     # test to check caiman get_input_movie_path()
     assert df.iloc[-1].caiman.get_input_movie_path() == get_full_raw_data_path(


### PR DESCRIPTION
Fixes #310. This is an API change for mcorr.get_shifts(). Changes in this PR:

- Don't return the first output of get_shifts anymore, since it was confusing/seemingly not very useful
- For piecewise case, return an n_dims-length list of n_frames x n_patches matrices rather than an n_dims*n_patches-length list of n_frames-length vectors.
- Remove the default value for `pw_rigid`, since it seemed too easy to forget to pass this and get an incorrect output as a result (came up when I was running the new test)
- Test the shifts against ground truth (currently only tests the piecewise case). I made a new zenodo upload with a shifts ground truth file. Note that this is based off of the upload for #309, so since that's not merged yet, the contour ground-truth tests will fail.