### PR TITLE
Use F order when reshaping masks

### DIFF
--- a/mesmerize_core/caiman_extensions/cnmf.py
+++ b/mesmerize_core/caiman_extensions/cnmf.py
@@ -227,7 +227,7 @@ class CNMFExtensions:
         masks = np.zeros(shape=(dims[0], dims[1], len(component_indices)), dtype=bool)
 
         for n, ix in enumerate(component_indices):
-            s = cnmf_obj.estimates.A[:, ix].toarray().reshape(cnmf_obj.dims)
+            s = cnmf_obj.estimates.A[:, ix].toarray().reshape(cnmf_obj.dims, order='F')
             s[s >= threshold] = 1
             s[s < threshold] = 0
 


### PR DESCRIPTION
As far as I know, spatial dimensions in A are always in F-order. I tried to use the `get_masks` function and the masks were not reshaped correctly.