### PR TITLE
Fix Github actions build issues

### DIFF
--- a/.github/workflows/linux-conda.yml
+++ b/.github/workflows/linux-conda.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Install mamba
       run: |
         mkdir -p $HOME/.conda_pkgs_cache
-        conda config --set pkgs_dirs $HOME/.conda_pkgs_cache
+        conda config --add pkgs_dirs "$HOME/.conda_pkgs_cache"
         conda install -c conda-forge mamba python=3.10
         conda clean -a
         

--- a/.github/workflows/linux-conda.yml
+++ b/.github/workflows/linux-conda.yml
@@ -27,12 +27,10 @@ jobs:
         
     - name: Install mamba
       run: |
+        mkdir -p $HOME/.conda_pkgs_cache
+        conda config --set pkgs_dirs $HOME/.conda_pkgs_cache
         conda install -c conda-forge mamba python=3.10
         conda clean -a
-        
-        #   - name: install caiman
-        #     run: |
-        #       mamba install -c conda-forge caiman
         
     - name: install mesmerize-core
       run: |

--- a/.github/workflows/linux-pip.yml
+++ b/.github/workflows/linux-pip.yml
@@ -35,7 +35,6 @@ jobs:
         cd ..
         git clone https://github.com/flatironinstitute/CaImAn.git
         cd CaImAn
-        pip install -r requirements.txt
         pip install .
         caimanmanager install
 

--- a/.github/workflows/macos-conda.yml
+++ b/.github/workflows/macos-conda.yml
@@ -20,11 +20,11 @@ jobs:
       with:
         architecture: 'x64'
         python-version: '3.10'
-        mamba-version: "*"
         channels: conda-forge,defaults
         channel-priority: true
         activate-environment: mescore
         environment-file: environment.yml
+        miniforge-version: latest
         
     - name: Test mesmerize-core with pytest
       shell: bash -el {0}

--- a/.github/workflows/macos-conda.yml
+++ b/.github/workflows/macos-conda.yml
@@ -13,13 +13,12 @@ jobs:
     runs-on: macos-latest
     strategy:
       max-parallel: 5
-      matrix:
-        architecture: ["x64"]
 
     steps:
     - uses: actions/checkout@v3
     - uses: conda-incubator/setup-miniconda@v3
       with:
+        architecture: 'x64'
         python-version: '3.10'
         mamba-version: "*"
         channels: conda-forge,defaults

--- a/.github/workflows/macos-conda.yml
+++ b/.github/workflows/macos-conda.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: macos-latest
     strategy:
       max-parallel: 5
+      matrix:
+        architecture: ["x64"]
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
I'm attempting to fix 3 completely different issues that are preventing tests from running:

- On linux pip, when installing caiman, `pip install -r requirements.txt` is failing because caiman no longer has a requirements.txt file. It shouldn't be necessary with all the dependencies listed in pyproject.toml now. However, this will still fail until flatironinstitute/CaImAn#1474 makes its way to main.
- On linux conda, there is a permissions error for the conda cache when installing mesmerize-core. Copilot suggested setting the cache dir manually instead of using the default.
- On macos conda, it seems the issue is related to the runner not having bundled conda due to being on ARM/Apple silicon architecture (conda-incubator/setup-miniconda#344). The latest suggestion there is to specify the architecture manually as x64.