### PR TITLE
Try causing a relative path error by using a drive alias

### DIFF
--- a/.github/workflows/windows-conda.yml
+++ b/.github/workflows/windows-conda.yml
@@ -32,6 +32,9 @@ jobs:
           
       - shell: bash -l {0}
         run: |
+          # make a drive letter alias so we can test canonical path resolution
+          subst Z: .
+          cd /z
           conda activate mescore
           mamba install pytest
           caimanmanager install


### PR DESCRIPTION
See #304 - I am seeing if I can reproduce the error in the Windows CI runner before this patch.