### PR TITLE
Allow spaces (and any other characters that work on the platform) in paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,6 +135,4 @@ dmypy.json
 .vscode/
 
 # test files
-tests/tmp
-tests/videos
-tests/ground_truths*
+tests/test data

--- a/environment.yml
+++ b/environment.yml
@@ -9,3 +9,4 @@ dependencies:
   - tqdm
   - psutil
   - filelock >= 3.15.1
+  - mslex

--- a/environment_rtd.yml
+++ b/environment_rtd.yml
@@ -9,3 +9,4 @@ dependencies:
   - psutil
   - pydata-sphinx-theme < 0.10.0
   - filelock >= 3.15.1
+  - mslex

--- a/mesmerize_core/batch_utils.py
+++ b/mesmerize_core/batch_utils.py
@@ -5,8 +5,6 @@ from typing import Union
 
 import pandas as pd
 
-from .utils import validate_path
-
 CURRENT_BATCH_PATH: Path = None  # only one batch at a time
 PARENT_DATA_PATH: Path = None
 
@@ -44,7 +42,7 @@ def set_parent_raw_data_path(path: Union[Path, str]) -> Path:
         Full parent data path
     """
     global PARENT_DATA_PATH
-    path = Path(validate_path(path))
+    path = Path(path)
     if not path.is_dir():
         raise NotADirectoryError(
             "The directory passed to `set_parent_raw_data_path()` does not exist.\n"
@@ -191,8 +189,6 @@ def load_batch(path: Union[str, Path]) -> pd.DataFrame:
 
     """
 
-    path = validate_path(path)
-
     df = pd.read_pickle(Path(path))
 
     df.paths.set_batch_path(path)
@@ -234,8 +230,6 @@ def create_batch(path: Union[str, Path], remove_existing: bool = False) -> pd.Da
         df = create_batch("/path/to/new_batch.pickle")
 
     """
-    path = validate_path(path)
-
     if Path(path).is_file():
         if remove_existing:
             os.remove(path)

--- a/mesmerize_core/caiman_extensions/common.py
+++ b/mesmerize_core/caiman_extensions/common.py
@@ -29,7 +29,7 @@ from ..batch_utils import (
     get_parent_raw_data_path,
     load_batch,
 )
-from ..utils import validate_path, IS_WINDOWS, make_runfile, warning_experimental
+from ..utils import IS_WINDOWS, make_runfile, warning_experimental
 from .cnmf import cnmf_cache
 from .. import algorithms
 from ..movie_readers import default_reader
@@ -113,7 +113,6 @@ class CaimanDataFrameExtensions:
 
         # make sure path is within batch dir or parent raw data path
         input_movie_path = self._df.paths.resolve(input_movie_path)
-        validate_path(input_movie_path)
 
         # get relative path
         input_movie_path = self._df.paths.split(input_movie_path)[1]

--- a/mesmerize_core/caiman_extensions/common.py
+++ b/mesmerize_core/caiman_extensions/common.py
@@ -9,7 +9,6 @@ from shutil import rmtree
 from datetime import datetime
 import time
 from copy import deepcopy
-import shlex
 
 import numpy as np
 import pandas as pd
@@ -33,6 +32,10 @@ from ..utils import IS_WINDOWS, make_runfile, warning_experimental
 from .cnmf import cnmf_cache
 from .. import algorithms
 from ..movie_readers import default_reader
+
+import shlex
+import mslex
+lex = mslex if IS_WINDOWS else shlex
 
 
 ALGO_MODULES = {
@@ -544,10 +547,7 @@ class CaimanSeriesExtensions:
 
         # Get the dir that contains the input movie
         parent_path = self._series.paths.resolve(self._series.input_movie_path).parent
-        if not IS_WINDOWS:
-            self.process = Popen(runfile_path, cwd=parent_path)
-        else:
-            self.process = Popen(f"powershell {runfile_path}", cwd=parent_path)
+        self.process = Popen([runfile_path], cwd=parent_path)
 
         if wait:
             self.process.wait()
@@ -646,16 +646,16 @@ class CaimanSeriesExtensions:
 
         # Create the runfile in the batch dir using this Series' UUID as the filename
         if IS_WINDOWS:
-            runfile_ext = ".ps1"
+            runfile_ext = ".bat"
         else:
             runfile_ext = ".runfile"
         runfile_path = str(
             batch_path.parent.joinpath(self._series["uuid"] + runfile_ext)
         )
 
-        args_str = f"--batch-path {batch_path} --uuid {self._series.uuid}"
+        args_str = f"--batch-path {lex.quote(str(batch_path))} --uuid {self._series.uuid}"
         if get_parent_raw_data_path() is not None:
-            args_str += f" --data-path {get_parent_raw_data_path()}"
+            args_str += f" --data-path {lex.quote(str(get_parent_raw_data_path()))}"
 
         # make the runfile
         runfile_path = make_runfile(
@@ -665,14 +665,8 @@ class CaimanSeriesExtensions:
             filename=runfile_path,  # path to create runfile
             args_str=args_str,
         )
-        try:
-            self.process = getattr(self, f"_run_{backend}")(
-                runfile_path, wait=wait, **kwargs
-            )
-        except:
-            with open(runfile_path, "r") as f:
-                raise ValueError(f.read())
 
+        self.process = getattr(self, f"_run_{backend}")(runfile_path, wait=wait, **kwargs)
         return self.process
 
     def get_input_movie_path(self) -> Path:

--- a/mesmerize_core/caiman_extensions/common.py
+++ b/mesmerize_core/caiman_extensions/common.py
@@ -35,6 +35,7 @@ from ..movie_readers import default_reader
 
 import shlex
 import mslex
+
 lex = mslex if IS_WINDOWS else shlex
 
 
@@ -653,7 +654,9 @@ class CaimanSeriesExtensions:
             batch_path.parent.joinpath(self._series["uuid"] + runfile_ext)
         )
 
-        args_str = f"--batch-path {lex.quote(str(batch_path))} --uuid {self._series.uuid}"
+        args_str = (
+            f"--batch-path {lex.quote(str(batch_path))} --uuid {self._series.uuid}"
+        )
         if get_parent_raw_data_path() is not None:
             args_str += f" --data-path {lex.quote(str(get_parent_raw_data_path()))}"
 
@@ -666,7 +669,9 @@ class CaimanSeriesExtensions:
             args_str=args_str,
         )
 
-        self.process = getattr(self, f"_run_{backend}")(runfile_path, wait=wait, **kwargs)
+        self.process = getattr(self, f"_run_{backend}")(
+            runfile_path, wait=wait, **kwargs
+        )
         return self.process
 
     def get_input_movie_path(self) -> Path:

--- a/mesmerize_core/utils.py
+++ b/mesmerize_core/utils.py
@@ -129,10 +129,12 @@ def make_runfile(
                 # that was active at the time that this shell script was generated
                 f.write(
                     f'{lex.quote(os.environ["CONDA_EXE"])} run -p {lex.quote(os.environ["CONDA_PREFIX"])} '
-                    f'python {lex.quote(module_path)} {args_str}'
+                    f"python {lex.quote(module_path)} {args_str}"
                 )
             else:
-                f.write(f"python {lex.quote(module_path)} {args_str}")  # call the script to run
+                f.write(
+                    f"python {lex.quote(module_path)} {args_str}"
+                )  # call the script to run
 
     else:
         with open(sh_file, "w") as f:
@@ -147,10 +149,8 @@ def make_runfile(
                 #         os.unlink(tmp.name)
                 #     except:
                 #         continue
-                f.write(
-                    f'SET {k}={lex.quote(v)};\n'
-                )
-            f.write(f'{lex.quote(sys.executable)} {lex.quote(module_path)} {args_str}')
+                f.write(f"SET {k}={lex.quote(v)};\n")
+            f.write(f"{lex.quote(sys.executable)} {lex.quote(module_path)} {args_str}")
 
     st = os.stat(sh_file)
     os.chmod(sh_file, st.st_mode | S_IEXEC)

--- a/mesmerize_core/utils.py
+++ b/mesmerize_core/utils.py
@@ -52,15 +52,6 @@ def warning_experimental(more_info: str = ""):
     return catcher
 
 
-def validate_path(path: Union[str, Path]):
-    if not regex.match(r"^[A-Za-z0-9@/\\:._-]*$", str(path)):
-        raise ValueError(
-            "Paths must only contain alphanumeric characters, "
-            "hyphens ( - ), underscores ( _ ) or periods ( . )"
-        )
-    return path
-
-
 def make_runfile(
     module_path: str, args_str: Optional[str] = None, filename: Optional[str] = None
 ) -> str:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ setuptools
 wheel
 numpy
 matplotlib
+mslex
 click
 psutil
 jupyterlab

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -35,8 +35,10 @@ from copy import deepcopy
 
 # don't call "resolve" on these - want to make sure we can handle non-canonical paths correctly
 tmp_dir = Path(os.path.dirname(os.path.abspath(__file__)), "test data", "tmp")
-vid_dir = Path(os.path.dirname(os.path.abspath(__file__)), "test data",  "videos")
-ground_truths_dir = Path(os.path.dirname(os.path.abspath(__file__)), "test data", "ground_truths")
+vid_dir = Path(os.path.dirname(os.path.abspath(__file__)), "test data", "videos")
+ground_truths_dir = Path(
+    os.path.dirname(os.path.abspath(__file__)), "test data", "ground_truths"
+)
 ground_truths_file = Path(
     os.path.dirname(os.path.abspath(__file__)), "test data", "ground_truths.zip"
 )

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -33,6 +33,7 @@ from mesmerize_core.caiman_extensions import cnmf
 import time
 import tifffile
 from copy import deepcopy
+import re
 
 tmp_dir = Path(os.path.dirname(os.path.abspath(__file__)), "tmp")
 vid_dir = Path(os.path.dirname(os.path.abspath(__file__)), "videos")
@@ -133,6 +134,8 @@ def teardown_module():
 
 def _create_tmp_batch() -> Tuple[pd.DataFrame, str]:
     fname = get_tmp_filename()
+    # add space to test support of paths with spaces
+    fname = re.sub(r'\.pickle$', ' batch.pickle', fname)
     df = create_batch(fname)
 
     return df, fname

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -33,13 +33,12 @@ from mesmerize_core.caiman_extensions import cnmf
 import time
 import tifffile
 from copy import deepcopy
-import re
 
-tmp_dir = Path(os.path.dirname(os.path.abspath(__file__)), "tmp")
-vid_dir = Path(os.path.dirname(os.path.abspath(__file__)), "videos")
-ground_truths_dir = Path(os.path.dirname(os.path.abspath(__file__)), "ground_truths")
+tmp_dir = Path(os.path.dirname(os.path.abspath(__file__)), "test data", "tmp")
+vid_dir = Path(os.path.dirname(os.path.abspath(__file__)), "test data",  "videos")
+ground_truths_dir = Path(os.path.dirname(os.path.abspath(__file__)), "test data", "ground_truths")
 ground_truths_file = Path(
-    os.path.dirname(os.path.abspath(__file__)), "ground_truths.zip"
+    os.path.dirname(os.path.abspath(__file__)), "test data", "ground_truths.zip"
 )
 
 os.makedirs(tmp_dir, exist_ok=True)
@@ -75,7 +74,8 @@ elif "DOWNLOAD_GROUND_TRUTHS" in os.environ.keys():
 
 
 def get_tmp_filename():
-    return os.path.join(tmp_dir, f"{uuid4()}.pickle")
+    # add a $ (legal on both UNIX and Windows) to ensure we are escaping it correctly
+    return os.path.join(tmp_dir, f"{uuid4()}$test.pickle")
 
 
 def clear_tmp():
@@ -134,8 +134,6 @@ def teardown_module():
 
 def _create_tmp_batch() -> Tuple[pd.DataFrame, str]:
     fname = get_tmp_filename()
-    # add space to test support of paths with spaces
-    fname = re.sub(r'\.pickle$', ' batch.pickle', fname)
     df = create_batch(fname)
 
     return df, fname


### PR DESCRIPTION
Here I am removing `validate_path` since we should be able to use any valid path. This first commit just removes validate_path and tweaks the tests so that each batch path has a space in it. As a result, most of the tests fail and print "Error: Got unexpected extra argument (batch.pickle)".  I am planning to use `shlex.quote` and [`mslex.quote`](https://github.com/smoofra/mslex) to fix the subprocess backend so this isn't a problem.

See comments on #304.