### PR TITLE
Adjust towards upstream changes to CNMF.fit() which removed the return value

### DIFF
--- a/mesmerize_core/algorithms/cnmf.py
+++ b/mesmerize_core/algorithms/cnmf.py
@@ -86,7 +86,7 @@ def run_algo(batch_path, uuid, data_path: str = None):
         cnm = cnmf.CNMF(n_processes, params=cnmf_params, dview=dview)
 
         print("fitting images")
-        cnm = cnm.fit(images)
+        cnm.fit(images)
         #
         if "refit" in params.keys():
             if params["refit"] is True:

--- a/mesmerize_core/algorithms/cnmfe.py
+++ b/mesmerize_core/algorithms/cnmfe.py
@@ -83,7 +83,7 @@ def run_algo(batch_path, uuid, data_path: str = None):
         cnmfe_params_dict = CNMFParams(params_dict=params_dict)
         cnm = cnmf.CNMF(n_processes=n_processes, dview=dview, params=cnmfe_params_dict)
         print("Performing CNMFE")
-        cnm = cnm.fit(images)
+        cnm.fit(images)
         print("evaluating components")
         cnm.estimates.evaluate_components(images, cnm.params, dview=dview)
 


### PR DESCRIPTION
Also fixes https://github.com/flatironinstitute/CaImAn/issues/1503