### PR TITLE
Fix environment not set correctly for Windows subprocess backend

### DIFF
--- a/mesmerize_core/utils.py
+++ b/mesmerize_core/utils.py
@@ -141,15 +141,7 @@ def make_runfile(
             for k, v in os.environ.items():  # copy the current environment
                 if regex.match(r"^.*[()]", str(k)) or regex.match(r"^.*[()]", str(v)):
                     continue
-                # with NamedTemporaryFile(suffix=".bat", delete=False, mode="w") as tmp:
-                #     try:  # windows powershell is stupid so make sure all the env var names work
-                #         tmp.write(f'$env:{k}="{v}";\n')
-                #         tmp.close()
-                #         check_call(f"powershell {tmp.name}")
-                #         os.unlink(tmp.name)
-                #     except:
-                #         continue
-                f.write(f"SET {k}={lex.quote(v)};\n")
+                f.write(f"SET {k}={lex.quote(v)}\n")
             f.write(f"{lex.quote(sys.executable)} {lex.quote(module_path)} {args_str}")
 
     st = os.stat(sh_file)


### PR DESCRIPTION
This is a follow-up on #327; not sure exactly why it didn't come up then, but maybe because I now have a UNC path as my working directory; cmd rejects this and defaults to C:\Windows. But the working directory shouldn't matter anyway.

I was getting this error:
```
Fatal Python error: _Py_HashRandomization_Init: failed to get random numbers to initialize Python
```
which apparently can happen when trying to invoke python using `Popen` if the environment isn't set correctly: https://stackoverflow.com/a/72845540

I realized that I was adding semicolons to the end of each `SET` line in the .bat file, which I believe was setting the variables to incorrect values. Deleting the semicolon fixed this for me.